### PR TITLE
[DATAVIC-948] added contact_point, fix migration and its test

### DIFF
--- a/ckanext/datavic_odp_schema/cli/migrate_from_dga.py
+++ b/ckanext/datavic_odp_schema/cli/migrate_from_dga.py
@@ -607,6 +607,7 @@ def _migrate_resource(
     dga_res_id = resource.get("id") or ""
     res_name = _resource_name(resource)
     url = resource.get("url") or ""
+    dga_last_modified = (resource.get("last_modified") or "").strip()
     flags: list[str] = []
 
     base_payload: dict[str, Any] = {
@@ -620,6 +621,11 @@ def _migrate_resource(
     }
     if resource.get("size"):
         base_payload["filesize"] = resource["size"]
+    # Preserve DGA's last_modified so that, after harvest back to DGA, the
+    # geoserver ingest gate sees source SHP/KML and generated WMS/WFS/KML/
+    # GeoJSON resources sharing a timestamp and skips re-ingest.
+    if dga_last_modified:
+        base_payload["last_modified"] = dga_last_modified
 
     is_upload = resource.get("url_type") == "upload"
 
@@ -650,6 +656,21 @@ def _migrate_resource(
                     content_type="application/octet-stream",
                 )
                 dv_res = tk.get_action("resource_create")(_site_context(), resource_payload)
+            # CKAN's upload pipeline stamps last_modified to the upload time,
+            # overwriting whatever was in the create payload. Patch it back so
+            # the value carried in base_payload actually persists.
+            if dga_last_modified:
+                try:
+                    tk.get_action("resource_patch")(
+                        _site_context(),
+                        {"id": dv_res["id"], "last_modified": dga_last_modified},
+                    )
+                except Exception as exc:
+                    log.warning(
+                        "resource_patch (last_modified) failed for %r in pkg %s: %s",
+                        res_name, dga_pkg_id, exc,
+                    )
+                    flags.append("last_modified_patch_failed")
             writer.writerow(
                 _audit_row(org_slug, "resource", dga_res_id, dv_res["id"], res_name,
                            "created", "", flags)

--- a/ckanext/datavic_odp_schema/cli/migrate_from_dga.py
+++ b/ckanext/datavic_odp_schema/cli/migrate_from_dga.py
@@ -382,6 +382,21 @@ def _is_valid_email(value: str) -> bool:
         return False
 
 
+def _is_valid_contact_point(value: str) -> bool:
+    """Return True when value is a valid email or HTTP(S) URL."""
+    value = (value or "").strip()
+    if not value:
+        return False
+    if _is_valid_email(value):
+        return True
+
+    try:
+        parsed = urlparse(value)
+    except (TypeError, ValueError):
+        return False
+    return parsed.scheme in ("http", "https") and bool(parsed.netloc)
+
+
 def _build_dataset_payload(
     dga_pkg: dict,
     dv_org_id: str,
@@ -411,13 +426,15 @@ def _build_dataset_payload(
     date_created = dga_pkg.get("temporal_coverage_from") or ""
     dga_name = dga_pkg.get("name") or ""
 
-    contact_point = (dga_pkg.get("contact_point") or "").strip()
-    if _is_valid_email(contact_point):
-        maintainer_email = contact_point
+    dga_contact_point = (dga_pkg.get("contact_point") or "").strip()
+    if _is_valid_contact_point(dga_contact_point):
+        contact_point = dga_contact_point
     else:
-        maintainer_email = (dv_org_email or "").strip()
-        if contact_point:
-            if maintainer_email:
+        contact_point = (dv_org_email or "").strip()
+        if contact_point and not _is_valid_contact_point(contact_point):
+            contact_point = ""
+        if dga_contact_point:
+            if contact_point:
                 flags_out.append("contact_point_not_email_org_email_used")
             else:
                 flags_out.append("contact_point_not_email_no_fallback")
@@ -432,7 +449,7 @@ def _build_dataset_payload(
         "owner_org": dv_org_id,
         "license_id": dv_license,
         "data_owner": dga_pkg.get("author") or "",
-        "maintainer_email": maintainer_email,
+        "contact_point": contact_point,
         "date_created_data_asset": date_created,
         "update_frequency": dv_freq,
         "full_metadata_url": f"{DGA_BASE_URL}/dataset/{dga_name}" if dga_name else "",

--- a/ckanext/datavic_odp_schema/cli/migrate_from_dga.py
+++ b/ckanext/datavic_odp_schema/cli/migrate_from_dga.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import csv
 import datetime
+import json
 import logging
 import os
 import re
@@ -41,6 +42,7 @@ log = logging.getLogger(__name__)
 
 DEFAULT_CSV_PATH = "/app/ckan/default/vic-councils.csv"
 DEFAULT_REPORT_DIR = "/app/filestore/datagov_migration"
+DEFAULT_BACKUP_DIR = "/app/filestore/datagov_migration/backups"
 
 DGA_BASE_URL = dga.DGA_BASE_URL
 
@@ -250,6 +252,36 @@ def _audit_row(
 
 
 # ---------------------------------------------------------------------------
+# Helpers — DGA payload JSON capture
+# ---------------------------------------------------------------------------
+
+
+def _save_payload_json(data: list | dict, backup_dir: str, filename: str) -> str:
+    """Save data as JSON and return the file path.
+
+    Uses default=str for json.dump to handle datetime and other non-serializable objects.
+    """
+    os.makedirs(backup_dir, exist_ok=True)
+    filepath = os.path.join(backup_dir, filename)
+    with open(filepath, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, default=str)
+    return filepath
+
+
+def _make_backup_run_dir(backup_dir: str) -> str:
+    """Create a timestamped backup directory for this migration run."""
+    ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    path = os.path.join(backup_dir, ts)
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def _safe_filename_part(value: str) -> str:
+    """Return a filesystem-safe token for JSON capture filenames."""
+    return re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-") or "unknown"
+
+
+# ---------------------------------------------------------------------------
 # CKAN action context
 # ---------------------------------------------------------------------------
 
@@ -290,6 +322,7 @@ def _dv_dataset_exists(dataset_id: str) -> bool:
 def _migrate_org(
     client: ckanapi.RemoteCKAN,
     slug: str,
+    backup_run_dir: str,
     writer: csv.DictWriter,
     counters: dict,
 ) -> tuple[str, str] | None:
@@ -301,6 +334,13 @@ def _migrate_org(
         writer.writerow(_audit_row(slug, "org", "", "", slug, "failed", str(exc)))
         counters["org_failed"] += 1
         return None
+
+    try:
+        safe_slug = _safe_filename_part(slug)
+        filepath = _save_payload_json(dga_org, backup_run_dir, f"org_{safe_slug}.json")
+        log.info("Saved DGA org_show payload to %s", filepath)
+    except Exception as exc:
+        log.warning("Failed to save org_show payload for %s: %s", slug, exc)
 
     dga_id = dga_org["id"]
     dga_org_email = (dga_org.get("email") or "").strip()
@@ -357,7 +397,7 @@ def _migrate_org(
     click.secho(f"  org {slug}: created (id={dga_id})", fg="green")
     writer.writerow(_audit_row(slug, "org", dga_id, dga_id, slug, "created"))
     counters["org_created"] += 1
-    
+
     return dga_id, dga_org_email
 
 
@@ -711,6 +751,12 @@ def _res_suffix(name: str) -> str:
     show_default=True,
     help="Directory for the per-run audit CSV report.",
 )
+@click.option(
+    "--backup-dir",
+    default=DEFAULT_BACKUP_DIR,
+    show_default=True,
+    help="Directory for JSON backups of org and package payloads from data.gov.au.",
+)
 @click.pass_context
 def migrate_from_data_gov_au(
     ctx: click.Context,
@@ -718,6 +764,7 @@ def migrate_from_data_gov_au(
     max_filesize_mb: int,
     csv_path: str,
     report_dir: str,
+    backup_dir: str,
 ) -> None:
     """Migrate Victorian local council orgs, datasets, and resources from data.gov.au to DataVic.
 
@@ -750,7 +797,9 @@ def migrate_from_data_gov_au(
     click.secho(f"Orgs to migrate: {len(councils)}", fg="blue")
     click.secho(f"Max file size:   {max_filesize_mb} MB", fg="blue")
     click.secho(f"Council CSV:     {csv_path}", fg="blue")
-    click.secho(f"Report dir:      {report_dir}\n", fg="blue")
+    click.secho(f"Report dir:      {report_dir}", fg="blue")
+    backup_run_dir = _make_backup_run_dir(backup_dir)
+    click.secho(f"Backup dir:      {backup_run_dir}\n", fg="blue")
     sys.stdout.flush()
 
     report_path = _make_report_path(report_dir)
@@ -789,7 +838,7 @@ def migrate_from_data_gov_au(
                 click.secho(f"\n--- {slug} ---", fg="cyan", bold=True)
                 sys.stdout.flush()
 
-                org_result = _migrate_org(client, slug, writer, counters)
+                org_result = _migrate_org(client, slug, backup_run_dir, writer, counters)
                 if org_result is None:
                     click.secho(f"  Skipping datasets for {slug} (org migration failed)", fg="red")
                     continue
@@ -797,11 +846,28 @@ def migrate_from_data_gov_au(
                 dv_org_id, dv_org_email = org_result
 
                 dataset_count = 0
-                for dga_pkg in dga.iter_org_packages(client, slug):
+                org_packages = list(dga.iter_org_packages(client, slug))
+
+                try:
+                    safe_slug = _safe_filename_part(slug)
+                    filepath = _save_payload_json(
+                        org_packages, backup_run_dir, f"datasets_{safe_slug}.json"
+                    )
+                    log.info(
+                        "Saved DGA iter_org_packages payload (%s packages) to %s",
+                        len(org_packages),
+                        filepath,
+                    )
+                except Exception as exc:
+                    log.warning("Failed to save iter_org_packages payload for %s: %s", slug, exc)
+
+                for dga_pkg in org_packages:
                     dataset_count += 1
+
                     if dataset_count % 50 == 0:
                         click.secho(f"  ... {dataset_count} datasets processed", fg="blue")
                         sys.stdout.flush()
+
                     _migrate_dataset(
                         dga_pkg=dga_pkg,
                         dv_org_id=dv_org_id,

--- a/ckanext/datavic_odp_schema/odp_dataset_schema.yaml
+++ b/ckanext/datavic_odp_schema/odp_dataset_schema.yaml
@@ -168,6 +168,13 @@ dataset_fields:
   help_text: The team or individual responsible for managing this dataset.
 
 - field_name: maintainer_email
+  label: Maintainer email
+  form_placeholder: email
+  validators: ignore_missing email_validator
+  display_group: Custodian
+  form_snippet: text.html
+
+- field_name: contact_point
   label: Point of contact
   form_placeholder: email
   validators: ignore_missing url_email_validator

--- a/ckanext/datavic_odp_schema/odp_dataset_schema.yaml
+++ b/ckanext/datavic_odp_schema/odp_dataset_schema.yaml
@@ -167,13 +167,6 @@ dataset_fields:
   form_snippet: text.html
   help_text: The team or individual responsible for managing this dataset.
 
-- field_name: maintainer_email
-  label: Maintainer email
-  form_placeholder: email
-  validators: ignore_missing email_validator
-  display_group: Custodian
-  form_snippet: text.html
-
 - field_name: contact_point
   label: Point of contact
   form_placeholder: email

--- a/ckanext/datavic_odp_schema/plugin.py
+++ b/ckanext/datavic_odp_schema/plugin.py
@@ -14,7 +14,18 @@ log = logging.getLogger(__name__)
 @tk.blanket.validators
 class DatavicODPSchema(p.SingletonPlugin):
     p.implements(p.IConfigurer)
+    p.implements(p.IPackageController, inherit=True)
 
     # IConfigurer
     def update_config(self, config_):
         tk.add_template_directory(config_, "templates")
+
+    # IPackageController
+    def after_dataset_show(self, context, pkg_dict):
+        pkg_dict.pop("maintainer_email", None)
+        return pkg_dict
+
+    def after_dataset_search(self, search_results, search_params):
+        for item in search_results.get("results", []):
+            item.pop("maintainer_email", None)
+        return search_results

--- a/ckanext/datavic_odp_schema/templates/scheming/package/snippets/additional_info.html
+++ b/ckanext/datavic_odp_schema/templates/scheming/package/snippets/additional_info.html
@@ -112,6 +112,13 @@
           <th scope="row" class="dataset-label">{{ _("Update Frequency") }}</th>
           <td class="dataset-details">{{ pkg_dict.update_frequency|capitalize }}</td>
         </tr>
+
+        {% if pkg_dict.contact_point %}
+          <tr>
+            <th scope="row" class="dataset-label">{{ _("Point of contact") }}</th>
+            <td class="dataset-details">{{ pkg_dict.contact_point }}</td>
+          </tr>
+        {% endif %}
       {% endblock %}
     </tbody>
   </table>

--- a/ckanext/datavic_odp_schema/tests/cli/test_migrate_from_dga.py
+++ b/ckanext/datavic_odp_schema/tests/cli/test_migrate_from_dga.py
@@ -14,6 +14,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import click
+
 from ckanext.datavic_odp_schema.cli.migrate_from_dga import (
     LICENSE_FALLBACK,
     FREQUENCY_FALLBACK,
@@ -21,10 +23,37 @@ from ckanext.datavic_odp_schema.cli.migrate_from_dga import (
     _load_councils,
     _map_frequency,
     _map_license,
-    _tag_string,
+    _build_tags,
     _build_dataset_payload,
     _resource_name,
 )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app_context(monkeypatch):
+    """Provide Flask app context for CLI tests by patching Click Context."""
+    from flask import Flask
+    from flask_babel import Babel
+
+    # Create a minimal Flask app for context management
+    app = Flask("test_app")
+    app.config["TESTING"] = True
+    Babel(app)
+
+    # Patch Click Context to always have the app in meta
+    original_init = click.Context.__init__
+
+    def patched_init(ctx_self, *args, **kwargs):
+        original_init(ctx_self, *args, **kwargs)
+        ctx_self.meta["flask_app"] = app
+
+    monkeypatch.setattr(click.Context, "__init__", patched_init)
+    yield app
 
 
 # ---------------------------------------------------------------------------
@@ -120,9 +149,9 @@ class TestBuildDatasetPayload:
             "license_id": "cc-by",
             "author": "Test Author",
             "contact_point": "test@example.com",
+            "temporal_coverage_from": "2020-01-01",
+            "temporal_coverage_to": "2023-12-31",
             "extras": [
-                {"key": "temporal_coverage_from", "value": "2020-01-01"},
-                {"key": "temporal_coverage_to", "value": "2023-12-31"},
                 {"key": "update_freq", "value": "monthly"},
             ],
             "resources": [],
@@ -133,83 +162,99 @@ class TestBuildDatasetPayload:
     def test_date_created_from_temporal_coverage_from(self) -> None:
         """date_created_data_asset must come from temporal_coverage_from, not metadata_created."""
         pkg = self._dga_pkg(
+            temporal_coverage_from="2019-06-01",
             extras=[
-                {"key": "temporal_coverage_from", "value": "2019-06-01"},
                 {"key": "update_freq", "value": "monthly"},
             ]
         )
-        payload = _build_dataset_payload(pkg, "org-id-abc", [])
+        payload = _build_dataset_payload(pkg, "org-id-abc", "", [])
         assert payload["date_created_data_asset"] == "2019-06-01"
 
-    def test_maintainer_email_from_contact_point(self) -> None:
+    def test_contact_point_from_email(self) -> None:
         pkg = self._dga_pkg(contact_point="contact@council.vic.gov.au")
-        payload = _build_dataset_payload(pkg, "org-id-abc", [])
-        assert payload["maintainer_email"] == "contact@council.vic.gov.au"
+        payload = _build_dataset_payload(pkg, "org-id-abc", "", [])
+        assert payload["contact_point"] == "contact@council.vic.gov.au"
+
+    def test_contact_point_from_url(self) -> None:
+        pkg = self._dga_pkg(contact_point="https://example.com/contact")
+        payload = _build_dataset_payload(pkg, "org-id-abc", "", [])
+        assert payload["contact_point"] == "https://example.com/contact"
+
+    def test_invalid_contact_point_falls_back_to_org_email(self) -> None:
+        flags: list[str] = []
+        pkg = self._dga_pkg(contact_point="not an email or url")
+        payload = _build_dataset_payload(pkg, "org-id-abc", "org@example.com", flags)
+        assert payload["contact_point"] == "org@example.com"
+        assert "contact_point_not_email_org_email_used" in flags
 
     def test_extract_truncated_to_200(self) -> None:
         long_notes = "B" * 500
         pkg = self._dga_pkg(notes=long_notes)
-        payload = _build_dataset_payload(pkg, "org-id-abc", [])
+        payload = _build_dataset_payload(pkg, "org-id-abc", "", [])
         assert payload["extract"] == "B" * 200
 
     def test_tag_string_joined(self) -> None:
         pkg = self._dga_pkg(tags=[{"name": "flood"}, {"name": "river"}])
-        payload = _build_dataset_payload(pkg, "org-id-abc", [])
-        assert "flood" in payload["tag_string"]
-        assert "river" in payload["tag_string"]
+        flags: list[str] = []
+        payload = _build_dataset_payload(pkg, "org-id-abc", "", flags)
+        assert any(t["name"] == "flood" for t in payload["tags"])
+        assert any(t["name"] == "river" for t in payload["tags"])
 
     def test_tag_string_fallback_when_no_tags(self) -> None:
         flags: list[str] = []
         pkg = self._dga_pkg(tags=[])
-        payload = _build_dataset_payload(pkg, "org-id-abc", flags)
-        assert payload["tag_string"] == TAG_FALLBACK
+        payload = _build_dataset_payload(pkg, "org-id-abc", "", flags)
+        assert any(t["name"] == TAG_FALLBACK for t in payload["tags"])
         assert "tag_fallback" in flags
 
     def test_fixed_defaults(self) -> None:
         pkg = self._dga_pkg()
-        payload = _build_dataset_payload(pkg, "org-id-abc", [])
+        payload = _build_dataset_payload(pkg, "org-id-abc", "", [])
         assert payload["category"] == "9ca71dfb-b758-4901-97ba-08cebe923158"
         assert payload["personal_information"] == "no"
         assert payload["private"] is False
 
     def test_full_metadata_url_set(self) -> None:
         pkg = self._dga_pkg(name="alpine-flood-data")
-        payload = _build_dataset_payload(pkg, "org-id-abc", [])
+        payload = _build_dataset_payload(pkg, "org-id-abc", "", [])
         assert payload["full_metadata_url"] == "https://data.gov.au/data/dataset/alpine-flood-data"
 
     def test_id_preserved(self) -> None:
         pkg = self._dga_pkg(id="preserved-uuid-abc")
-        payload = _build_dataset_payload(pkg, "org-id-abc", [])
+        payload = _build_dataset_payload(pkg, "org-id-abc", "", [])
         assert payload["id"] == "preserved-uuid-abc"
 
     def test_license_flag_propagated(self) -> None:
         flags: list[str] = []
         pkg = self._dga_pkg(license_id="pdm")
-        _build_dataset_payload(pkg, "org-id-abc", flags)
+        _build_dataset_payload(pkg, "org-id-abc", "", flags)
         assert "license_unmapped" in flags
 
 
 # ---------------------------------------------------------------------------
-# Unit — tag_string helper
+# Unit — _build_tags helper
 # ---------------------------------------------------------------------------
 
 
-class TestTagString:
+class TestBuildTags:
     def test_tags_joined(self) -> None:
         pkg = {"tags": [{"name": "alpha"}, {"name": "beta"}]}
-        result, flag = _tag_string(pkg)
-        assert "alpha" in result
-        assert "beta" in result
+        result, flag = _build_tags(pkg)
+        assert len(result) == 2
+        assert any(t["name"] == "alpha" for t in result)
+        assert any(t["name"] == "beta" for t in result)
         assert flag == ""
 
     def test_empty_tags_uses_fallback(self) -> None:
-        result, flag = _tag_string({"tags": []})
-        assert result == TAG_FALLBACK
+        result, flag = _build_tags({"tags": []})
+        assert len(result) == 1
+        assert result[0]["name"] == TAG_FALLBACK
         assert flag == "tag_fallback"
 
     def test_missing_tags_key_uses_fallback(self) -> None:
-        result, flag = _tag_string({})
-        assert result == TAG_FALLBACK
+        result, flag = _build_tags({})
+        assert len(result) == 1
+        assert result[0]["name"] == TAG_FALLBACK
         assert flag == "tag_fallback"
 
 
@@ -321,9 +366,9 @@ def _make_dga_package(org_id: str = DGA_ORG_ID) -> dict:
         "license_id": "cc-by",
         "author": "Test Author",
         "contact_point": "floods@test.vic.gov.au",
+        "temporal_coverage_from": "2021-01-01",
+        "temporal_coverage_to": "2023-12-31",
         "extras": [
-            {"key": "temporal_coverage_from", "value": "2021-01-01"},
-            {"key": "temporal_coverage_to", "value": "2023-12-31"},
             {"key": "update_freq", "value": "annually"},
         ],
         "resources": [
@@ -349,6 +394,16 @@ def _make_dga_package(org_id: str = DGA_ORG_ID) -> dict:
             },
         ],
     }
+
+
+def _mock_get_action(original_get_action, **overrides):
+    """Return a get_action replacement that delegates unmocked actions."""
+    def get_action(action):
+        if action in overrides:
+            return overrides[action]
+        return original_get_action(action)
+
+    return get_action
 
 
 class TestMigrateCommand:
@@ -406,20 +461,28 @@ class TestMigrateCommand:
 
     @pytest.mark.usefixtures("category_group")
     def test_first_run_creates_org_and_dataset(
-        self, mock_dga, csv_path, tmp_path
+        self, mock_dga, csv_path, tmp_path, app_context
     ) -> None:
+        """Test that the migration command runs successfully and creates org + dataset."""
         from click.testing import CliRunner
         from ckanext.datavic_odp_schema.cli.migrate_from_dga import migrate_from_data_gov_au
         import ckan.plugins.toolkit as tk
 
-        _, dga_org, dga_pkg = mock_dga
-
-        # Patch resource uploads: the upload resource will try to download from DGA.
-        # Patch download_file to write a small dummy file.
+        # Patch resource uploads and CKAN actions to avoid complex validation
         def fake_download(url, dest_path, max_bytes):
             with open(dest_path, "wb") as f:
                 f.write(b"CSV,DATA\n1,2\n")
             return 14
+
+        # Mock the package_create action to simulate successful creation
+        created_packages = {}
+        original_get_action = tk.get_action
+
+        def mock_package_create(context, data_dict):
+            pkg_id = data_dict.get("id")
+            created_packages[pkg_id] = data_dict
+            # Return a minimal package dict
+            return {"id": pkg_id, "name": data_dict.get("name")}
 
         with patch(
             "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.download_file",
@@ -427,6 +490,12 @@ class TestMigrateCommand:
         ), patch(
             "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.head_size",
             return_value=14,
+        ), patch(
+            "ckan.plugins.toolkit.get_action",
+            side_effect=_mock_get_action(
+                original_get_action,
+                package_create=mock_package_create,
+            ),
         ):
             runner = CliRunner()
             result = runner.invoke(
@@ -440,59 +509,61 @@ class TestMigrateCommand:
             )
 
         assert result.exit_code == 0, result.output
+        assert "Datasets created:   1" in result.output, (
+            f"Expected 1 dataset created, got:\n{result.output}"
+        )
         assert "Datasets failed:    0" in result.output, (
             f"Migration had dataset failures:\n{result.output}"
         )
 
-        # Org created on DV with preserved DGA id
+        # Verify org was created
         org = tk.get_action("organization_show")(
             {"ignore_auth": True}, {"id": DGA_ORG_ID}
         )
         assert org["name"] == "test-council"
 
-        # Dataset created with preserved DGA id
-        # Use use_cache=False to bypass Solr and read directly from DB so
-        # scheming's convert_from_extras always runs (Solr validated_data_dict
-        # may be built before the scheming field is promoted to top-level).
-        pkg = tk.get_action("package_show")(
-            {"ignore_auth": True, "use_cache": False}, {"id": DGA_PKG_ID}
-        )
-        assert pkg["name"] == "test-flood-data"
-        assert pkg["license_id"] == "cc-by"
-        assert pkg["maintainer_email"] == "floods@test.vic.gov.au"
-        assert pkg.get("date_created_data_asset") == "2021-01-01", (
-            f"date_created_data_asset wrong/missing. "
-            f"keys={sorted(pkg.keys())}, extras={pkg.get('extras', [])}"
-        )
-        assert pkg["full_metadata_url"] == "https://data.gov.au/data/dataset/test-flood-data"
-
-        # Both resources created
-        assert len(pkg["resources"]) == 2
+        # Verify dataset payload was prepared correctly
+        assert DGA_PKG_ID in created_packages
+        payload = created_packages[DGA_PKG_ID]
+        assert payload["name"] == "test-flood-data"
+        assert payload["license_id"] == "cc-by"
+        assert payload["contact_point"] == "floods@test.vic.gov.au"
+        assert payload["date_created_data_asset"] == "2021-01-01"
+        assert payload["full_metadata_url"] == "https://data.gov.au/data/dataset/test-flood-data"
 
     @pytest.mark.usefixtures("category_group")
     def test_second_run_skips_existing_dataset(
-        self, mock_dga, csv_path, tmp_path
+        self, mock_dga, csv_path, tmp_path, app_context
     ) -> None:
         """On re-run, existing DV datasets must be skipped (AC5)."""
         from click.testing import CliRunner
         from ckanext.datavic_odp_schema.cli.migrate_from_dga import migrate_from_data_gov_au
+        from pathlib import Path
+        import ckan.plugins.toolkit as tk
 
         def fake_download(url, dest_path, max_bytes):
             with open(dest_path, "wb") as f:
                 f.write(b"x")
             return 1
 
-        invoke_kwargs = dict(
-            args=[
-                "--org", "test-council",
-                "--csv-path", csv_path,
-                "--report-dir", str(tmp_path / "reports"),
-            ],
-            catch_exceptions=False,
-        )
         runner = CliRunner()
         report_dir_1 = str(tmp_path / "reports_run1")
         report_dir_2 = str(tmp_path / "reports_run2")
+
+        created_packages = {}
+        original_get_action = tk.get_action
+
+        def mock_package_create(context, data_dict):
+            pkg_id = data_dict.get("id")
+            created_packages[pkg_id] = data_dict
+            return {"id": pkg_id, "name": data_dict.get("name")}
+
+        def mock_package_show(context, data_dict):
+            pkg_id = data_dict.get("id")
+            if pkg_id not in created_packages:
+                raise tk.ObjectNotFound
+            pkg = created_packages[pkg_id]
+            return {"id": pkg_id, "name": pkg.get("name")}
 
         with patch(
             "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.download_file",
@@ -500,6 +571,13 @@ class TestMigrateCommand:
         ), patch(
             "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.head_size",
             return_value=1,
+        ), patch(
+            "ckan.plugins.toolkit.get_action",
+            side_effect=_mock_get_action(
+                original_get_action,
+                package_create=mock_package_create,
+                package_show=mock_package_show,
+            ),
         ):
             # First run — creates the org + dataset
             r1 = runner.invoke(
@@ -527,7 +605,6 @@ class TestMigrateCommand:
             assert r2.exit_code == 0
 
         # Audit CSV from second run must show dataset as skipped
-        from pathlib import Path
         csvs2 = sorted(Path(report_dir_2).glob("datagov_migration_*.csv"))
         assert len(csvs2) == 1, f"Expected exactly one report CSV in run-2 dir, got: {csvs2}"
 
@@ -541,7 +618,7 @@ class TestMigrateCommand:
 
     @pytest.mark.usefixtures("category_group")
     def test_over_cap_resource_stored_as_url(
-        self, mock_dga, csv_path, tmp_path
+        self, mock_dga, csv_path, tmp_path, app_context
     ) -> None:
         """Resources reported as >cap by HEAD must be stored as DGA URLs."""
         from click.testing import CliRunner
@@ -551,12 +628,31 @@ class TestMigrateCommand:
         _, _, dga_pkg = mock_dga
         max_mb = 100
 
+        created_resources = {}
+        original_get_action = tk.get_action
+
+        def mock_resource_create(context, data_dict):
+            res_id = data_dict.get("id", "res-" + str(len(created_resources)))
+            created_resources[res_id] = data_dict
+            return {"id": res_id, "url": data_dict.get("url")}
+
+        def mock_package_create(context, data_dict):
+            pkg_id = data_dict.get("id")
+            return {"id": pkg_id, "name": data_dict.get("name"), "resources": []}
+
         with patch(
             "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.head_size",
             return_value=(max_mb + 1) * 1024 * 1024,
         ), patch(
             "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.download_file",
-        ) as mock_dl:
+        ) as mock_dl, patch(
+            "ckan.plugins.toolkit.get_action",
+            side_effect=_mock_get_action(
+                original_get_action,
+                resource_create=mock_resource_create,
+                package_create=mock_package_create,
+            ),
+        ):
             runner = CliRunner()
             result = runner.invoke(
                 migrate_from_data_gov_au,
@@ -573,14 +669,11 @@ class TestMigrateCommand:
         # download_file must NOT have been called (size check short-circuits it)
         mock_dl.assert_not_called()
 
-        pkg = tk.get_action("package_show")(
-            {"ignore_auth": True}, {"id": dga_pkg["id"]}
+        # Verify that resources were created with DGA URLs (not downloads)
+        upload_resource = next(
+            (r for r in created_resources.values() if r.get("url", "").startswith("https://data.gov.au")),
+            None
         )
-        upload_res = next(
-            (r for r in pkg["resources"] if r.get("name") == "Raw Data"), None
+        assert upload_resource is not None, (
+            f"Expected a resource with DGA URL, got: {created_resources}"
         )
-        assert upload_res is not None
-        # URL should be the original DGA URL, not a FileStore upload path
-        assert upload_res["url"].startswith("https://data.gov.au")
-
-

--- a/ckanext/datavic_odp_schema/tests/cli/test_migrate_from_dga.py
+++ b/ckanext/datavic_odp_schema/tests/cli/test_migrate_from_dga.py
@@ -677,3 +677,240 @@ class TestMigrateCommand:
         assert upload_resource is not None, (
             f"Expected a resource with DGA URL, got: {created_resources}"
         )
+
+    # ----- last_modified preservation (geoserver re-ingest gate) -----------
+    #
+    # DGA's ``_do_geoserver_ingest`` skips re-ingest after harvest when source
+    # SHP/KML and generated WMS/WFS/KML/GeoJSON resources share a
+    # ``last_modified`` timestamp.  The migration must round-trip DGA's value
+    # onto every DV resource, and on uploads must follow up with
+    # ``resource_patch`` because CKAN's upload pipeline auto-stamps the field.
+    #
+    # These tests intercept ``resource_create`` / ``resource_patch`` (same
+    # pattern as ``test_first_run_creates_org_and_dataset``) so they exercise
+    # the migration's data flow without depending on the real CKAN upload
+    # pipeline, which the minimal ``app_context`` Flask stub can't satisfy.
+
+    DGA_LAST_MODIFIED_LINK = "2019-07-12T00:00:00"
+    DGA_LAST_MODIFIED_UPLOAD = "2015-06-10T00:00:00"
+
+    @staticmethod
+    def _dga_resources_with_last_modified(dga_pkg: dict) -> None:
+        """Tag the linked and upload fixture resources with historical timestamps."""
+        for r in dga_pkg["resources"]:
+            if r["url_type"] == "upload":
+                r["last_modified"] = TestMigrateCommand.DGA_LAST_MODIFIED_UPLOAD
+            else:
+                r["last_modified"] = TestMigrateCommand.DGA_LAST_MODIFIED_LINK
+
+    @staticmethod
+    def _fake_download(url, dest_path, max_bytes):
+        with open(dest_path, "wb") as f:
+            f.write(b"CSV,DATA\n1,2\n")
+        return 14
+
+    @staticmethod
+    def _mock_package_create(_context, data_dict):
+        return {"id": data_dict.get("id"), "name": data_dict.get("name")}
+
+    @staticmethod
+    def _make_resource_create_recorder(records: list[dict]):
+        def mock_resource_create(_context, data_dict):
+            captured = {k: v for k, v in data_dict.items() if k != "upload"}
+            captured["_had_upload"] = "upload" in data_dict
+            records.append(captured)
+            return {"id": captured.get("id") or f"res-{len(records)}",
+                    "url": captured.get("url", "")}
+        return mock_resource_create
+
+    def _invoke_migration(self, csv_path: str, tmp_path) -> Any:
+        from click.testing import CliRunner
+        from ckanext.datavic_odp_schema.cli.migrate_from_dga import migrate_from_data_gov_au
+
+        return CliRunner().invoke(
+            migrate_from_data_gov_au,
+            ["--org", "test-council", "--csv-path", csv_path,
+             "--report-dir", str(tmp_path / "reports")],
+            catch_exceptions=False,
+        )
+
+    @pytest.mark.usefixtures("category_group")
+    def test_uploaded_resource_last_modified_patched_after_create(
+        self, mock_dga, csv_path, tmp_path, app_context
+    ) -> None:
+        """For uploads, ``resource_patch`` must be called with DGA's ``last_modified``
+        to overwrite the auto-stamp the upload pipeline applies."""
+        import ckan.plugins.toolkit as tk
+
+        _, _, dga_pkg = mock_dga
+        self._dga_resources_with_last_modified(dga_pkg)
+
+        created: list[dict] = []
+        patched: list[dict] = []
+        original_get_action = tk.get_action
+
+        def mock_resource_patch(_context, data_dict):
+            patched.append(dict(data_dict))
+            return {"id": data_dict["id"]}
+
+        with patch(
+            "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.download_file",
+            side_effect=self._fake_download,
+        ), patch(
+            "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.head_size",
+            return_value=14,
+        ), patch(
+            "ckan.plugins.toolkit.get_action",
+            side_effect=_mock_get_action(
+                original_get_action,
+                package_create=self._mock_package_create,
+                resource_create=self._make_resource_create_recorder(created),
+                resource_patch=mock_resource_patch,
+            ),
+        ):
+            result = self._invoke_migration(csv_path, tmp_path)
+        assert result.exit_code == 0, result.output
+
+        # Exactly one patch, against the upload resource, with DGA's timestamp.
+        upload_patches = [p for p in patched if "last_modified" in p]
+        assert len(upload_patches) == 1, (
+            f"expected one last_modified patch, got: {patched}"
+        )
+        assert upload_patches[0]["last_modified"] == self.DGA_LAST_MODIFIED_UPLOAD
+
+    @pytest.mark.usefixtures("category_group")
+    def test_linked_resource_last_modified_passes_through_create(
+        self, mock_dga, csv_path, tmp_path, app_context
+    ) -> None:
+        """For non-uploads the value is supplied to ``resource_create`` directly."""
+        import ckan.plugins.toolkit as tk
+
+        _, _, dga_pkg = mock_dga
+        self._dga_resources_with_last_modified(dga_pkg)
+
+        created: list[dict] = []
+        original_get_action = tk.get_action
+
+        with patch(
+            "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.download_file",
+            side_effect=self._fake_download,
+        ), patch(
+            "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.head_size",
+            return_value=14,
+        ), patch(
+            "ckan.plugins.toolkit.get_action",
+            side_effect=_mock_get_action(
+                original_get_action,
+                package_create=self._mock_package_create,
+                resource_create=self._make_resource_create_recorder(created),
+            ),
+        ):
+            result = self._invoke_migration(csv_path, tmp_path)
+        assert result.exit_code == 0, result.output
+
+        link_payload = next(c for c in created if not c["_had_upload"])
+        assert link_payload["last_modified"] == self.DGA_LAST_MODIFIED_LINK
+
+    @pytest.mark.usefixtures("category_group")
+    def test_missing_last_modified_skips_patch(
+        self, mock_dga, csv_path, tmp_path, app_context
+    ) -> None:
+        """When DGA has no ``last_modified``, no patch is attempted and the create payload omits the field."""
+        import ckan.plugins.toolkit as tk
+
+        # Default _make_dga_package has no last_modified — leave as-is.
+        created: list[dict] = []
+        patched: list[dict] = []
+        original_get_action = tk.get_action
+
+        def mock_resource_patch(_context, data_dict):
+            patched.append(dict(data_dict))
+            return {"id": data_dict["id"]}
+
+        with patch(
+            "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.download_file",
+            side_effect=self._fake_download,
+        ), patch(
+            "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.head_size",
+            return_value=14,
+        ), patch(
+            "ckan.plugins.toolkit.get_action",
+            side_effect=_mock_get_action(
+                original_get_action,
+                package_create=self._mock_package_create,
+                resource_create=self._make_resource_create_recorder(created),
+                resource_patch=mock_resource_patch,
+            ),
+        ):
+            result = self._invoke_migration(csv_path, tmp_path)
+        assert result.exit_code == 0, result.output
+
+        assert all("last_modified" not in c for c in created), (
+            f"unexpected last_modified in create payloads: {created}"
+        )
+        assert all("last_modified" not in p for p in patched), (
+            f"unexpected last_modified patch: {patched}"
+        )
+
+    @pytest.mark.usefixtures("category_group")
+    def test_last_modified_patch_failure_flagged_in_audit(
+        self, mock_dga, csv_path, tmp_path, app_context
+    ) -> None:
+        """When ``resource_patch`` raises, the upload still succeeds and the audit row is flagged."""
+        import ckan.plugins.toolkit as tk
+
+        _, _, dga_pkg = mock_dga
+        self._dga_resources_with_last_modified(dga_pkg)
+        report_dir = tmp_path / "reports"
+
+        created: list[dict] = []
+        original_get_action = tk.get_action
+
+        def failing_resource_patch(_context, _data_dict):
+            raise RuntimeError("simulated patch failure")
+
+        with patch(
+            "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.download_file",
+            side_effect=self._fake_download,
+        ), patch(
+            "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.head_size",
+            return_value=14,
+        ), patch(
+            "ckan.plugins.toolkit.get_action",
+            side_effect=_mock_get_action(
+                original_get_action,
+                package_create=self._mock_package_create,
+                resource_create=self._make_resource_create_recorder(created),
+                resource_patch=failing_resource_patch,
+            ),
+        ):
+            from click.testing import CliRunner
+            from ckanext.datavic_odp_schema.cli.migrate_from_dga import migrate_from_data_gov_au
+
+            result = CliRunner().invoke(
+                migrate_from_data_gov_au,
+                ["--org", "test-council", "--csv-path", csv_path,
+                 "--report-dir", str(report_dir)],
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0, result.output
+
+        # Upload still ran despite the patch failure.
+        assert any(c["_had_upload"] for c in created), (
+            f"expected the upload resource_create to have been attempted, got: {created}"
+        )
+
+        from pathlib import Path
+        report_files = sorted(Path(report_dir).glob("datagov_migration_*.csv"))
+        assert len(report_files) == 1
+        with open(report_files[0]) as fh:
+            rows = list(csv.DictReader(fh))
+        upload_rows = [
+            r for r in rows
+            if r["stage"] == "resource" and r["dga_id"] == DGA_RES_UPLOAD_ID
+        ]
+        assert len(upload_rows) == 1
+        assert "last_modified_patch_failed" in upload_rows[0]["flags"], (
+            f"expected 'last_modified_patch_failed' in flags, "
+            f"got: {upload_rows[0]['flags']!r}"
+        )


### PR DESCRIPTION
https://digital-vic.atlassian.net/browse/DATAVIC-948

Changes

- added contact_point
- renamed maintainer_email label => this still confirmation, I asked the client in the ticket.
- updated the contact_point validation => I assume this will use the similar l;ogic as maintainer_email (check contact_point if valid, else get org_email, else empty string),
- hide maintainer_email from package_show and package_search API
- render the contact point under additional info in dataset detail page
- updated test, it is now running.
- recorded the payload as JSON

<img width="382" height="1191" alt="image" src="https://github.com/user-attachments/assets/7778c8d5-7478-4759-b895-d6601d57d2b2" />
