### PR TITLE
Release: 2.10.6 - non-VPS publishing to DV

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,143 @@
+# ckanext-datavic-odp-schema
+
+CKAN extension providing the DataVic Open Data Portal (ODP) dataset and organisation schemas, CLI management commands, and related helpers.
+
+---
+
+## CLI commands
+
+All commands run under the `datavic-odp` group:
+
+```sh
+ckan -c $CKAN_INI datavic-odp --help
+```
+
+### `migrate-from-data-gov-au` (DATAVIC-923)
+
+Migrates Victorian local council orgs, datasets, and resources from data.gov.au into DataVic. Safe to re-run — existing DV datasets (matched by preserved DGA id) are skipped.
+
+```sh
+ckan -c $CKAN_INI datavic-odp migrate-from-data-gov-au [OPTIONS]
+
+Options:
+  --org SLUG            Org slug(s) to migrate (repeatable). Omit to migrate all 39 councils.
+  --max-filesize-mb N   Files larger than N MB are stored as DGA URLs (default: 100).
+  --csv-path PATH       Path to council list CSV (default: /app/ckan/default/vic-councils.csv).
+  --report-dir PATH     Directory for the per-run audit CSV (default: /app/filestore/datagov_migration).
+```
+
+---
+
+## Running tests
+
+### Prerequisites
+
+Tests run inside the `ckan` container where the full CKAN stack (PostgreSQL, Solr, virtualenv) is available. Ensure the stack is up before running any integration tests.
+
+From `datavic_ckan_odp_lagoon/`:
+
+```sh
+# Start all services
+docker compose -f docker-compose.yml -f docker-compose.local.yml up -d
+
+# Verify the ckan container is running
+docker compose -f docker-compose.yml -f docker-compose.local.yml ps
+```
+
+Or using ahoy (if installed):
+
+```sh
+ahoy up
+```
+
+### Installing the `ckanapi` dependency
+
+`ckanapi` is listed in `requirements.txt` and is installed automatically when the extension is built into the image. If you are iterating on a running container without a rebuild, install it manually:
+
+```sh
+docker compose -f docker-compose.yml -f docker-compose.local.yml exec ckan sh -c \
+  '. /app/ckan/default/bin/activate && pip install "ckanapi>=4.7"'
+```
+
+### Initialising the test database
+
+The integration tests use CKAN's `clean_db` fixture, which requires a `ckan_test` database. Create it and initialise the schema once per environment (or after `down --volumes`):
+
+```sh
+# 1. Create the test database
+docker compose -f docker-compose.yml -f docker-compose.local.yml exec postgres \
+  psql postgresql://ckan:ckan@postgres/postgres -c "CREATE DATABASE ckan_test OWNER ckan;"
+
+# 2. Initialise CKAN tables in the test database
+docker compose -f docker-compose.yml -f docker-compose.local.yml exec ckan sh -c \
+  '. /app/ckan/default/bin/activate && \
+   ckan -c /app/src/ckanext-datavic-odp-schema/test.ini db init'
+```
+
+### Running the test suite
+
+Shell into the `ckan` container. `ahoy ckan` activates the venv automatically; otherwise activate it manually:
+
+```sh
+# ahoy — opens an interactive shell with venv pre-activated
+ahoy ckan
+
+# docker compose — activate the venv manually after entering
+docker compose -f docker-compose.yml -f docker-compose.local.yml exec ckan sh
+. /app/ckan/default/bin/activate
+```
+
+Then navigate to the extension and run pytest:
+
+```sh
+cd /app/src/ckanext-datavic-odp-schema
+```
+
+**All extension tests:**
+
+```sh
+pytest ckanext/datavic_odp_schema/tests/ -v
+```
+
+**Migration tests only (`test_migrate_from_dga.py`):**
+
+```sh
+pytest ckanext/datavic_odp_schema/tests/cli/test_migrate_from_dga.py -v
+```
+
+**Unit tests only (no DB required — mapping logic, CSV loader):**
+
+```sh
+pytest ckanext/datavic_odp_schema/tests/cli/test_migrate_from_dga.py -v \
+  -k "not TestMigrateCommand"
+```
+
+`setup.cfg` configures pytest to use `test.ini` automatically (`addopts = --ckan-ini test.ini`), so no extra `-p` flag is needed.
+
+### Test structure
+
+| Module | Type | Requires DB |
+| --- | --- | --- |
+| `tests/cli/test_migrate_from_dga.py::TestLicenseMap` | Unit | No |
+| `tests/cli/test_migrate_from_dga.py::TestFrequencyMap` | Unit | No |
+| `tests/cli/test_migrate_from_dga.py::TestBuildDatasetPayload` | Unit | No |
+| `tests/cli/test_migrate_from_dga.py::TestTagString` | Unit | No |
+| `tests/cli/test_migrate_from_dga.py::TestResourceName` | Unit | No |
+| `tests/cli/test_migrate_from_dga.py::TestLoadCouncils` | Unit | No |
+| `tests/cli/test_migrate_from_dga.py::TestMigrateCommand` | Integration | Yes (`clean_db`) |
+| `tests/test_helpers.py` | Unit + Integration | Some |
+
+### One-liner (from the host)
+
+Run just the unit tests without entering the container:
+
+```sh
+# docker compose
+docker compose -f docker-compose.yml -f docker-compose.local.yml exec -T ckan sh -c \
+  '. /app/ckan/default/bin/activate && \
+   cd /app/src/ckanext-datavic-odp-schema && \
+   pytest ckanext/datavic_odp_schema/tests/cli/test_migrate_from_dga.py -v -k "not TestMigrateCommand"'
+
+# ahoy
+ahoy run ckan '. /app/ckan/default/bin/activate && cd /app/src/ckanext-datavic-odp-schema && pytest ckanext/datavic_odp_schema/tests/cli/test_migrate_from_dga.py -v -k "not TestMigrateCommand"'
+```

--- a/ckanext/datavic_odp_schema/cli/__init__.py
+++ b/ckanext/datavic_odp_schema/cli/__init__.py
@@ -4,8 +4,10 @@ import click
 from ckan.plugins.toolkit import enqueue_job
 from ckanext.datavic_odp_schema import jobs
 
+from . import detached_export
 from . import maintain
 from . import reconcile
+from . import sync_from_dd
 
 __all__ = [
     "datavic_odp",
@@ -31,3 +33,5 @@ def ckan_worker_job_monitor():
 
 datavic_odp.add_command(maintain.maintain)
 datavic_odp.add_command(reconcile.reconcile_datasets)
+datavic_odp.add_command(detached_export.export_detached_syndicated_datasets)
+datavic_odp.add_command(sync_from_dd.sync_syndicated_fields)

--- a/ckanext/datavic_odp_schema/cli/__init__.py
+++ b/ckanext/datavic_odp_schema/cli/__init__.py
@@ -6,6 +6,7 @@ from ckanext.datavic_odp_schema import jobs
 
 from . import detached_export
 from . import maintain
+from . import migrate_from_dga
 from . import reconcile
 from . import sync_from_dd
 
@@ -32,6 +33,7 @@ def ckan_worker_job_monitor():
 
 
 datavic_odp.add_command(maintain.maintain)
+datavic_odp.add_command(migrate_from_dga.migrate_from_data_gov_au)
 datavic_odp.add_command(reconcile.reconcile_datasets)
 datavic_odp.add_command(detached_export.export_detached_syndicated_datasets)
 datavic_odp.add_command(sync_from_dd.sync_syndicated_fields)

--- a/ckanext/datavic_odp_schema/cli/dd_api.py
+++ b/ckanext/datavic_odp_schema/cli/dd_api.py
@@ -22,6 +22,8 @@ import ckan.plugins.toolkit as tk
 
 _CFG_DD_URL = "ckanext.datavic_odp.reconciliation.dd_url"
 _CFG_DD_API_KEY = "ckanext.datavic_odp.reconciliation.dd_api_key"
+_CFG_API_TOKEN_HEADER = "apitoken_header_name"
+_DEFAULT_API_TOKEN_HEADER = "X-CKAN-API-Key"
 
 REQUEST_TIMEOUT = 30  # seconds
 
@@ -44,6 +46,14 @@ def _dd_api_key() -> str:
             f"or the corresponding environment variable."
         )
     return key
+
+
+def _dd_auth_headers(dd_api_key: str) -> dict[str, str]:
+    header_name = (
+        tk.config.get(_CFG_API_TOKEN_HEADER, "").strip()
+        or _DEFAULT_API_TOKEN_HEADER
+    )
+    return {header_name: dd_api_key}
 
 
 def _get_extra(pkg: dict[str, Any], key: str) -> str | None:
@@ -87,7 +97,7 @@ def _fetch_dd_search_page(
             "rows": _PAGE_SIZE,
             "start": start,
         },
-        headers={"Authorization": dd_api_key},
+        headers=_dd_auth_headers(dd_api_key),
         timeout=REQUEST_TIMEOUT,
     )
     resp.raise_for_status()
@@ -114,7 +124,7 @@ def fetch_dd_active_packages(
     resp = requests.get(
         f"{dd_url}/api/3/action/package_search",
         params={"fq": _SEARCH_FQ, "rows": _PAGE_SIZE, "start": 0},
-        headers={"Authorization": dd_api_key},
+        headers=_dd_auth_headers(dd_api_key),
         timeout=REQUEST_TIMEOUT,
     )
     resp.raise_for_status()
@@ -181,7 +191,7 @@ def dd_package_show(
     resp = requests.get(
         f"{dd_url}/api/3/action/package_show",
         params={"id": id_or_name},
-        headers={"Authorization": dd_api_key},
+        headers=_dd_auth_headers(dd_api_key),
         timeout=REQUEST_TIMEOUT,
     )
     if resp.status_code == 404:

--- a/ckanext/datavic_odp_schema/cli/dd_api.py
+++ b/ckanext/datavic_odp_schema/cli/dd_api.py
@@ -1,0 +1,193 @@
+"""Shared DD (Data Directory) API helpers for reconciliation and sync.
+
+Used by reconcile, sync_from_dd, and detached_export. Reads config from
+ckanext.datavic_odp.reconciliation.dd_url and dd_api_key (e.g. DD_RECONCILIATION_URL,
+DD_RECONCILIATION_API_KEY).
+"""
+
+from __future__ import annotations
+
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any
+
+import click
+import requests
+
+import ckan.plugins.toolkit as tk
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+_CFG_DD_URL = "ckanext.datavic_odp.reconciliation.dd_url"
+_CFG_DD_API_KEY = "ckanext.datavic_odp.reconciliation.dd_api_key"
+
+REQUEST_TIMEOUT = 30  # seconds
+
+
+def _dd_url() -> str:
+    url = tk.config.get(_CFG_DD_URL, "").strip().rstrip("/")
+    if not url:
+        raise click.ClickException(
+            f"DD URL not configured.  Set {_CFG_DD_URL} in ckan.ini "
+            f"or the corresponding environment variable."
+        )
+    return url
+
+
+def _dd_api_key() -> str:
+    key = tk.config.get(_CFG_DD_API_KEY, "").strip()
+    if not key:
+        raise click.ClickException(
+            f"DD API key not configured.  Set {_CFG_DD_API_KEY} in ckan.ini "
+            f"or the corresponding environment variable."
+        )
+    return key
+
+
+def _get_extra(pkg: dict[str, Any], key: str) -> str | None:
+    """Extract an extra value from a CKAN package dict.
+
+    Also checks top-level key (e.g. package_show may flatten extras).
+    """
+    val = pkg.get(key)
+    if val is not None and val != "":
+        return str(val) if not isinstance(val, str) else val
+    for extra in pkg.get("extras", []):
+        if extra.get("key") == key:
+            v = extra.get("value")
+            return str(v) if v is not None else None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# DD API
+# ---------------------------------------------------------------------------
+
+_SEARCH_FQ = (
+    "+state:active "
+    "+extras_workflow_status:published "
+    "+extras_organization_visibility:all"
+)
+_PAGE_SIZE = 1000
+_MAX_PAGE_WORKERS = 8
+
+
+def _fetch_dd_search_page(
+    dd_url: str,
+    dd_api_key: str,
+    start: int,
+) -> tuple[int, list[dict[str, Any]]]:
+    """Fetch one page of DD package_search. Returns (start, results)."""
+    resp = requests.get(
+        f"{dd_url}/api/3/action/package_search",
+        params={
+            "fq": _SEARCH_FQ,
+            "rows": _PAGE_SIZE,
+            "start": start,
+        },
+        headers={"Authorization": dd_api_key},
+        timeout=REQUEST_TIMEOUT,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    if not data.get("success"):
+        raise click.ClickException(
+            f"DD package_search failed: {data.get('error', data)}"
+        )
+    results = data["result"].get("results") or []
+    return (start, results)
+
+
+def fetch_dd_active_packages(
+    dd_url: str,
+    dd_api_key: str,
+    progress_callback: None | Any = None,
+) -> list[dict[str, Any]]:
+    """Fetch all active DD dataset package dicts via paginated package_search.
+
+    Same fq as reconcile: active, workflow_status=published, organization_visibility=all.
+    First page is fetched to get total count; remaining pages are fetched in parallel.
+    """
+    # First page: get count and initial results (API returns "count" in result)
+    resp = requests.get(
+        f"{dd_url}/api/3/action/package_search",
+        params={"fq": _SEARCH_FQ, "rows": _PAGE_SIZE, "start": 0},
+        headers={"Authorization": dd_api_key},
+        timeout=REQUEST_TIMEOUT,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    if not data.get("success"):
+        raise click.ClickException(
+            f"DD package_search failed: {data.get('error', data)}"
+        )
+    result = data["result"]
+    packages = list(result.get("results") or [])
+    total_count = result.get("count", len(packages))
+
+    if total_count <= _PAGE_SIZE:
+        if progress_callback:
+            progress_callback(len(packages), total_count)
+        else:
+            click.secho(
+                f"  Fetched {len(packages)} DD datasets (total: {total_count})...",
+                fg="blue",
+            )
+            sys.stdout.flush()
+        return packages
+
+    # Remaining page offsets: 1000, 2000, ...
+    page_starts = list(range(_PAGE_SIZE, total_count, _PAGE_SIZE))
+    page_results: dict[int, list] = {}
+
+    with ThreadPoolExecutor(max_workers=min(_MAX_PAGE_WORKERS, len(page_starts))) as executor:
+        future_to_start = {}
+        for s in page_starts:
+            future = executor.submit(_fetch_dd_search_page, dd_url, dd_api_key, s)
+            future_to_start[future] = s
+        for future in as_completed(future_to_start):
+            s, results = future.result()
+            page_results[s] = results
+            n_so_far = len(packages) + sum(len(r) for r in page_results.values())
+            if progress_callback:
+                progress_callback(n_so_far, total_count)
+            else:
+                click.secho(
+                    f"  Fetched {n_so_far}/{total_count} DD datasets...",
+                    fg="blue",
+                )
+                sys.stdout.flush()
+
+    for s in sorted(page_results):
+        packages.extend(page_results[s])
+
+    return packages
+
+
+def dd_package_show(
+    dd_url: str, dd_api_key: str, id_or_name: str
+) -> dict[str, Any] | None:
+    """Call DD package_show.
+
+    Returns:
+        dict: Dataset found on DD.
+        None: Dataset not found (404 or unsuccessful response).
+
+    Raises:
+        requests.RequestException: API error (network, timeout, server error).
+    """
+    resp = requests.get(
+        f"{dd_url}/api/3/action/package_show",
+        params={"id": id_or_name},
+        headers={"Authorization": dd_api_key},
+        timeout=REQUEST_TIMEOUT,
+    )
+    if resp.status_code == 404:
+        return None
+    resp.raise_for_status()
+    data = resp.json()
+    if data.get("success"):
+        return data["result"]
+    return None

--- a/ckanext/datavic_odp_schema/cli/detached_export.py
+++ b/ckanext/datavic_odp_schema/cli/detached_export.py
@@ -1,0 +1,402 @@
+"""Export detached DD-DV dataset pairs with comparison to CSV.
+
+DV datasets that have the same name as a DD dataset but are not linked by
+syndicated_id are "detached". This command compares dataset and resource
+metadata and writes one row per pair to CSV for review.
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any
+
+import click
+
+import ckan.model as model
+import ckan.plugins.toolkit as tk
+
+from . import dd_api
+
+log = __import__("logging").getLogger(__name__)
+
+# Default directory for detached export CSV (when --csv-path not set). Adjust as needed.
+DEFAULT_DETACHED_CSV_DIR = "/app/filestore/detached_syndicated_reports"
+
+# Dataset fields to compare (from odp_dataset_schema.yaml dataset_fields),
+# excluding category and personal_information. Adjust when schema changes.
+DATASET_MATCH_FIELDS = [
+    "title",
+    "name",
+    "alias",
+    "notes",
+    "extract",
+    "tag_string",
+    "owner_org",
+    "license_id",
+    "custom_licence_text",
+    "custom_licence_link",
+    "date_created_data_asset",
+    "update_frequency",
+    "full_metadata_url",
+    "dtv_preview",
+    "data_owner",
+    "maintainer_email",
+    "nominated_view_id",
+    "nominated_view_resource",
+]
+
+RESOURCE_MATCH_FIELDS = [
+    "name",
+    "description",
+    "release_date",
+    "period_start",
+    "period_end",
+    "data_quality",
+    "attribution",
+]
+
+# ---------------------------------------------------------------------------
+# Field resolution
+# ---------------------------------------------------------------------------
+
+
+def _get_package_field_value(pkg: dict[str, Any], field: str) -> str:
+    """Get dataset field value from package dict (top-level or extras)."""
+    val = pkg.get(field)
+    if val is not None and str(val).strip() != "":
+        return str(val).strip()
+    for extra in pkg.get("extras", []):
+        if extra.get("key") == field:
+            v = extra.get("value")
+            if v is not None and str(v).strip() != "":
+                return str(v).strip()
+    return ""
+
+
+def _normalize(val: Any) -> str:
+    """Normalize for comparison: None/empty -> empty string."""
+    if val is None:
+        return ""
+    s = str(val).strip()
+    return s
+
+
+def _is_external_resource_url(url: str | None) -> bool:
+    """Return True if resource URL is external (not filestore/upload)."""
+    if not url or not url.strip():
+        return False
+    url = url.strip()
+    storage_path = tk.config.get("ckan.storage_path", "").strip()
+    if storage_path and url.startswith(storage_path):
+        return False
+    site_url = (tk.config.get("ckan.site_url") or "").strip().rstrip("/")
+    if site_url:
+        if url.startswith(site_url + "/dataset/") or url.startswith(site_url + "/filestore/"):
+            return False
+    if "/filestore/" in url:
+        return False
+    return True
+
+
+def _resource_fields_to_compare(resource: dict[str, Any]) -> list[str]:
+    """List of resource fields to compare; includes url if external."""
+    fields = list(RESOURCE_MATCH_FIELDS)
+    if _is_external_resource_url(resource.get("url")):
+        fields = fields + ["url"]
+    return fields
+
+
+def _get_resource_value(res: dict[str, Any], field: str) -> str:
+    """Get resource field value."""
+    return _normalize(res.get(field))
+
+
+# ---------------------------------------------------------------------------
+# Comparison
+# ---------------------------------------------------------------------------
+
+
+def _compare_datasets(
+    dd_pkg: dict[str, Any],
+    dv_pkg: dict[str, Any],
+    dataset_fields: list[str],
+) -> tuple[bool, list[str]]:
+    """Compare dataset-level fields. Return (all_match, list of differing field names)."""
+    differing = []
+    for field in dataset_fields:
+        dd_val = _normalize(_get_package_field_value(dd_pkg, field))
+        dv_val = _normalize(_get_package_field_value(dv_pkg, field))
+        if dd_val != dv_val:
+            differing.append(field)
+    return (len(differing) == 0, differing)
+
+
+def _compare_resources(
+    dd_resources: list[dict[str, Any]],
+    dv_resources: list[dict[str, Any]],
+) -> tuple[bool, list[str], list[str]]:
+    """Compare resources by index. Return (all_match, resource_mismatch_lines, missing_lines)."""
+    dd_n = len(dd_resources)
+    dv_n = len(dv_resources)
+    mismatch_parts: list[str] = []
+    missing_parts: list[str] = []
+
+    if dd_n > dv_n:
+        for i in range(dv_n, dd_n):
+            missing_parts.append(f"resource {i + 1} missing from DV")
+    elif dv_n > dd_n:
+        for i in range(dd_n, dv_n):
+            missing_parts.append(f"resource {i + 1} missing from DD")
+
+    n = min(dd_n, dv_n)
+    all_match = True
+    for i in range(n):
+        dd_res = dd_resources[i]
+        dv_res = dv_resources[i]
+        fields = _resource_fields_to_compare(dd_res)
+        # If DV resource is external, also compare url for that resource
+        if _is_external_resource_url(dv_res.get("url")) and "url" not in fields:
+            fields = fields + ["url"]
+        diff_fields = []
+        for f in fields:
+            if _get_resource_value(dd_res, f) != _get_resource_value(dv_res, f):
+                diff_fields.append(f)
+                all_match = False
+        if diff_fields:
+            mismatch_parts.append(f"Resource {i + 1}: {', '.join(diff_fields)}")
+
+    if missing_parts:
+        all_match = False
+    return (all_match, mismatch_parts, missing_parts)
+
+
+def _build_comment(
+    dataset_diff: list[str],
+    resource_mismatches: list[str],
+    resource_missing: list[str],
+) -> str:
+    """Build single comment string for CSV."""
+    parts = []
+    if dataset_diff:
+        parts.append("Dataset: " + ", ".join(dataset_diff))
+    if resource_mismatches:
+        parts.append("; ".join(resource_mismatches))
+    if resource_missing:
+        parts.append("; ".join(resource_missing))
+    return "; ".join(parts) if parts else ""
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+_CSV_COLUMNS = [
+    "dd_package_id",
+    "dd_name",
+    "dv_package_id",
+    "dv_name",
+    "dataset_match",
+    "dd_resource_total",
+    "dv_resource_total",
+    "all_resources_match",
+    "comment",
+]
+
+
+def _fetch_dd_package(
+    dd_url: str, dd_api_key: str, dd_name: str
+) -> tuple[str, dict[str, Any] | None]:
+    """Fetch one DD package by name. For use in thread pool. Returns (dd_name, pkg or None)."""
+    try:
+        pkg = dd_api.dd_package_show(dd_url, dd_api_key, dd_name)
+        return (dd_name, pkg)
+    except Exception as e:
+        log.warning("DD package_show %s: %s", dd_name, e)
+        return (dd_name, None)
+
+
+@click.command("export-detached-syndicated-datasets")
+@click.option(
+    "--csv-path",
+    default=None,
+    type=click.Path(),
+    help="Path for the CSV report. Default: <detached_csv_dir>/dv_detached_syndicated_<timestamp>.csv",
+)
+@click.option(
+    "--workers",
+    default=10,
+    type=click.IntRange(1, 50),
+    help="Number of parallel workers for DD API calls (default 10).",
+)
+def export_detached_syndicated_datasets(csv_path: str | None, workers: int) -> None:
+    """Export detached DD-DV dataset pairs with comparison to CSV.
+
+    Detached = same name on DD and DV but DD's syndicated_id is empty or
+    points to a different DV package. For each pair, compares dataset and
+    resource metadata and writes one row per pair.
+    """
+    click.secho("=== Export detached syndicated datasets ===\n", fg="cyan", bold=True)
+    sys.stdout.flush()
+
+    dd_url = dd_api._dd_url()
+    dd_api_key = dd_api._dd_api_key()
+    click.secho(f"DD URL: {dd_url}", fg="blue")
+    sys.stdout.flush()
+
+    # Fetch DD active packages
+    click.secho("Fetching DD active dataset reference set...", fg="blue")
+    sys.stdout.flush()
+    dd_packages = dd_api.fetch_dd_active_packages(dd_url, dd_api_key)
+    dd_by_name = {p["name"]: p for p in dd_packages}
+    dd_names = set(dd_by_name)
+    dd_syndicated_ids = {
+        name: (dd_api._get_extra(pkg, "syndicated_id") or "")
+        for name, pkg in dd_by_name.items()
+    }
+    click.secho(f"  DD reference: {len(dd_names)} active datasets.\n", fg="green")
+    sys.stdout.flush()
+
+    # DV datasets
+    click.secho("Fetching DV local datasets...", fg="blue")
+    sys.stdout.flush()
+    dv_rows = (
+        model.Session.query(
+            model.Package.id,
+            model.Package.name,
+        )
+        .filter(model.Package.type == "dataset")
+        .all()
+    )
+    click.secho(f"  DV local: {len(dv_rows)} datasets.\n", fg="green")
+    sys.stdout.flush()
+
+    # Detached: same name on DD but syndicated_id != dv_id (or empty)
+    detached = []
+    for dv_id, dv_name in dv_rows:
+        if dv_name not in dd_names:
+            continue
+        sid = dd_syndicated_ids.get(dv_name, "")
+        if sid and sid == dv_id:
+            continue
+        dd_pkg_summary = dd_by_name[dv_name]
+        detached.append((dd_pkg_summary["id"], dd_pkg_summary["name"], dv_id, dv_name))
+
+    click.secho(f"Detached pairs (same name, not linked): {len(detached)}\n", fg="blue")
+    sys.stdout.flush()
+
+    # Fetch all DD packages in parallel (each unique dd_name once).
+    # submit() queues work; worker threads run up to `workers` calls at a time.
+    # We collect results as they complete (as_completed) and fill dd_pkg_by_name.
+    unique_dd_names = list({dd_name for _, dd_name, _, _ in detached})
+    click.secho(f"Fetching {len(unique_dd_names)} DD packages ({workers} workers)...", fg="blue")
+    sys.stdout.flush()
+    dd_pkg_by_name: dict[str, dict[str, Any] | None] = {}
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        future_to_name = {}
+        for name in unique_dd_names:
+            future = executor.submit(_fetch_dd_package, dd_url, dd_api_key, name)
+            future_to_name[future] = name
+
+        done = 0
+        for future in as_completed(future_to_name):
+            dd_name, pkg = future.result()
+            dd_pkg_by_name[dd_name] = pkg
+            done += 1
+            if done % 50 == 0 or done == len(unique_dd_names):
+                click.secho(f"  DD fetched {done}/{len(unique_dd_names)}...", fg="blue")
+                sys.stdout.flush()
+
+    click.secho("  DD fetch complete.\n", fg="green")
+    sys.stdout.flush()
+
+    dataset_fields = DATASET_MATCH_FIELDS
+    context = {"model": model, "session": model.Session, "ignore_auth": True}
+    context["user"] = tk.get_action("get_site_user")(context, {})["name"]
+
+    rows = []
+    for i, (dd_id, dd_name, dv_id, dv_name) in enumerate(detached):
+        if (i + 1) % 100 == 0 or i == 0:
+            click.secho(f"  Comparing pair {i + 1}/{len(detached)}: {dv_name}...", fg="blue")
+            sys.stdout.flush()
+
+        dd_pkg = dd_pkg_by_name.get(dd_name)
+        if dd_pkg is None:
+            rows.append({
+                "dd_package_id": dd_id,
+                "dd_name": dd_name,
+                "dv_package_id": dv_id,
+                "dv_name": dv_name,
+                "dataset_match": "No",
+                "dd_resource_total": "",
+                "dv_resource_total": "",
+                "all_resources_match": "No",
+                "comment": "DD package_show returned empty or failed",
+            })
+            continue
+
+        try:
+            dv_pkg = tk.get_action("package_show")(context, {"id": dv_id})
+        except Exception as e:
+            log.warning("Error fetching DV package %s: %s", dv_id, e)
+            rows.append({
+                "dd_package_id": dd_id,
+                "dd_name": dd_name,
+                "dv_package_id": dv_id,
+                "dv_name": dv_name,
+                "dataset_match": "No",
+                "dd_resource_total": str(len(dd_pkg.get("resources") or [])),
+                "dv_resource_total": "",
+                "all_resources_match": "No",
+                "comment": f"Error: {e}",
+            })
+            continue
+
+        dd_resources = dd_pkg.get("resources") or []
+        dv_resources = dv_pkg.get("resources") or []
+
+        dataset_ok, dataset_diff = _compare_datasets(
+            dd_pkg, dv_pkg, dataset_fields
+        )
+        resources_ok, res_mismatches, res_missing = _compare_resources(
+            dd_resources, dv_resources
+        )
+
+        comment = _build_comment(dataset_diff, res_mismatches, res_missing)
+
+        rows.append({
+            "dd_package_id": dd_id,
+            "dd_name": dd_name,
+            "dv_package_id": dv_id,
+            "dv_name": dv_name,
+            "dataset_match": "Yes" if dataset_ok else "No",
+            "dd_resource_total": str(len(dd_resources)),
+            "dv_resource_total": str(len(dv_resources)),
+            "all_resources_match": "Yes" if resources_ok else "No",
+            "comment": comment,
+        })
+
+    if not csv_path:
+        ts = __import__("datetime").datetime.now().strftime("%Y%m%d_%H%M%S")
+        csv_path = os.path.join(
+            DEFAULT_DETACHED_CSV_DIR.rstrip("/"),
+            f"dv_detached_syndicated_{ts}.csv",
+        )
+    csv_dir = os.path.dirname(csv_path)
+    if csv_dir:
+        os.makedirs(csv_dir, exist_ok=True)
+    with open(csv_path, "w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=_CSV_COLUMNS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    click.secho(f"\nCSV written to {csv_path}", fg="green")
+    same_name_count = len([r for r in dv_rows if r[1] in dd_names])
+    linked_count = len([r for r in dv_rows if r[1] in dd_names and dd_syndicated_ids.get(r[1]) == r[0]])
+    click.secho(
+        f"Summary: DV datasets={len(dv_rows)}, same name on DD={same_name_count} (linked={linked_count}, detached={len(detached)})",
+        fg="cyan",
+    )
+    sys.stdout.flush()

--- a/ckanext/datavic_odp_schema/cli/dga_client.py
+++ b/ckanext/datavic_odp_schema/cli/dga_client.py
@@ -1,0 +1,101 @@
+"""DGA (data.gov.au) CKAN API client.
+
+Wraps ``ckanapi.RemoteCKAN`` for organisation and package queries, plus
+``requests``-based helpers for file downloads and HEAD size checks.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from typing import Generator, Iterator
+
+import ckanapi
+import requests
+
+log = logging.getLogger(__name__)
+
+DGA_BASE_URL = "https://data.gov.au/data"
+_CHUNK_SIZE = 1024 * 256  # 256 KB
+_DOWNLOAD_TIMEOUT = 60  # seconds
+
+
+def get_dga_client() -> ckanapi.RemoteCKAN:
+    """Return a read-only RemoteCKAN client pointed at data.gov.au."""
+    return ckanapi.RemoteCKAN(DGA_BASE_URL, get_only=True)
+
+
+def org_show(client: ckanapi.RemoteCKAN, slug: str) -> dict:
+    """Fetch an organisation from DGA by slug.
+
+    Raises ``ckanapi.NotFound`` if the org does not exist.
+    """
+    return client.action.organization_show(id=slug, include_datasets=False)
+
+
+def iter_org_packages(
+    client: ckanapi.RemoteCKAN, org_slug: str, batch_size: int = 1000
+) -> Iterator[dict]:
+    """Yield all public dataset dicts for a DGA org, paginated.
+
+    Uses ``package_search`` (which returns full package dicts including
+    ``resources``, ``tags``, ``extras`` — no per-dataset ``package_show``
+    call needed).
+    """
+    start = 0
+    while True:
+        result = client.action.package_search(
+            fq=f"organization:{org_slug}",
+            rows=batch_size,
+            start=start,
+            include_private=False,
+        )
+
+        packages = result.get("results", [])
+        if not packages:
+            break
+        yield from packages
+        start += len(packages)
+        if start >= result.get("count", 0):
+            break
+
+
+def head_size(url: str) -> int | None:
+    """Return Content-Length from a HEAD request, or None if unavailable."""
+    try:
+        resp = requests.head(url, allow_redirects=True, timeout=_DOWNLOAD_TIMEOUT)
+        resp.raise_for_status()
+        length = resp.headers.get("Content-Length")
+        return int(length) if length is not None else None
+    except Exception as exc:
+        log.debug("HEAD %s failed: %s", url, exc)
+        return None
+
+
+def download_file(url: str, dest_path: str, max_bytes: int) -> int:
+    """Stream-download ``url`` to ``dest_path``.
+
+    Returns the number of bytes written.
+
+    Raises ``FileTooLargeError`` if the download exceeds ``max_bytes``
+    mid-stream (file is left partially written — callers should clean up).
+    """
+    total = 0
+    with requests.get(url, stream=True, timeout=_DOWNLOAD_TIMEOUT) as resp:
+        resp.raise_for_status()
+        with open(dest_path, "wb") as fh:
+            for chunk in resp.iter_content(chunk_size=_CHUNK_SIZE):
+                if not chunk:
+                    continue
+                total += len(chunk)
+                if total > max_bytes:
+                    raise FileTooLargeError(
+                        f"Download exceeded {max_bytes} bytes at {total} bytes"
+                    )
+                fh.write(chunk)
+    return total
+
+
+class FileTooLargeError(Exception):
+    """Raised when a resource download exceeds the configured size cap."""

--- a/ckanext/datavic_odp_schema/cli/migrate_from_dga.py
+++ b/ckanext/datavic_odp_schema/cli/migrate_from_dga.py
@@ -1,0 +1,924 @@
+"""Migrate Victorian local council orgs, datasets, and resources from data.gov.au to DataVic.
+
+Acceptance criteria covered: AC1 (orgs), AC2 (datasets), AC3 (resources), AC5 (re-run safety).
+AC4 (external harvest round-trip) requires no script changes — it depends only on preserved IDs.
+
+Usage
+-----
+    ckan -c $CKAN_INI datavic-odp migrate-from-data-gov-au [--org SLUG] [--max-filesize-mb N]
+
+Reads the bundled council list from ``/app/ckan/default/vic-councils.csv`` by default.
+Pass ``--csv-path`` to override (useful for local testing).
+"""
+
+from __future__ import annotations
+
+import csv
+import datetime
+import json
+import logging
+import os
+import re
+import sys
+import tempfile
+from typing import Any
+from urllib.parse import urlparse
+from werkzeug.datastructures import FileStorage
+
+import click
+import ckanapi
+
+import ckan.model as model
+import ckan.plugins.toolkit as tk
+from ckan.model import Package
+
+from . import dga_client as dga
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_CSV_PATH = "/app/ckan/default/vic-councils.csv"
+DEFAULT_REPORT_DIR = "/app/filestore/datagov_migration"
+DEFAULT_BACKUP_DIR = "/app/filestore/datagov_migration/backups"
+
+DGA_BASE_URL = dga.DGA_BASE_URL
+
+# Fixed dataset defaults (AC2)
+FIXED_CATEGORY = "9ca71dfb-b758-4901-97ba-08cebe923158"
+FIXED_PERSONAL_INFO = "no"
+
+# Fallback tag when the DGA dataset has no tags
+TAG_FALLBACK = "local government"
+
+# License mapping: DGA license_id → DV license_id
+LICENSE_MAP: dict[str, str] = {
+    "cc-by": "cc-by",
+    "cc-by-2.5": "cc-by",
+    "cc-by-4.0": "cc-by",
+    "cc-by-sa": "cc-by-sa",
+    "cc-nc": "cc-nc",
+    "other-nc": "cc-nc",
+    "other": "other",
+    "other-open": "other",
+    "other-forsale": "other",
+    "other-unpublished": "other",
+    "pdm": "other",
+    "oecd-data": "other",
+}
+LICENSE_FALLBACK = "cc-by"
+
+# Update-frequency mapping: DGA extras[update_freq] → DV update_frequency
+# Schema enum casing is authoritative (asNeeded, notPlanned, not lowercase).
+FREQUENCY_MAP: dict[str, str] = {
+    "daily": "daily",
+    "weekly": "weekly",
+    "monthly": "monthly",
+    "quarterly": "quarterly",
+    "biannually": "biannually",
+    "biennaully": "biannually",  # DGA typo for "biennially"
+    "annually": "annually",
+    "infrequently": "irregular",
+    "other": "unknown",
+    "never": "notPlanned",
+}
+FREQUENCY_FALLBACK = "unknown"
+
+# Audit CSV columns
+_REPORT_COLUMNS = [
+    "org_slug",
+    "stage",
+    "dga_id",
+    "dv_id",
+    "name",
+    "status",
+    "reason",
+    "flags",
+]
+
+PACKAGE_NAME_MAX_LENGTH = getattr(Package, "name_max_length", 100)
+
+# ---------------------------------------------------------------------------
+# Helpers — field mapping
+# ---------------------------------------------------------------------------
+
+
+def _get_extra(pkg: dict, key: str) -> str:
+    """Return extra value from a CKAN package dict, or empty string."""
+    for extra in pkg.get("extras", []):
+        if extra.get("key") == key:
+            return extra.get("value") or ""
+    return ""
+
+
+def _map_license(dga_license_id: str) -> tuple[str, str]:
+    """Map a DGA license_id to a DV license_id.
+
+    Returns ``(dv_license_id, flag)`` where flag is one of:
+    ``''`` (clean match), ``'license_unmapped'`` (no DV equivalent, using other),
+    ``'license_fallback'`` (empty/unknown, defaulting to cc-by).
+    """
+    if not dga_license_id:
+        return LICENSE_FALLBACK, "license_fallback"
+    mapped = LICENSE_MAP.get(dga_license_id)
+    if mapped:
+        # Flag licenses with no true DV equivalent
+        if dga_license_id in ("pdm", "oecd-data", "other-forsale", "other-unpublished"):
+            return mapped, "license_unmapped"
+        return mapped, ""
+    return LICENSE_FALLBACK, "license_fallback"
+
+
+def _map_frequency(pkg: dict) -> tuple[str, str]:
+    """Map DGA extras[update_freq] to DV update_frequency.
+
+    Returns ``(dv_value, flag)`` where flag is ``'freq_fallback'`` when the
+    field is absent/empty, else ``''``.
+    """
+    raw = _get_extra(pkg, "update_freq").strip().lower()
+    if not raw:
+        return FREQUENCY_FALLBACK, "freq_fallback"
+    mapped = FREQUENCY_MAP.get(raw)
+    if mapped:
+        return mapped, ""
+    return FREQUENCY_FALLBACK, "freq_fallback"
+
+
+def _build_tags(pkg: dict) -> tuple[list[dict[str, str]], str]:
+    """Build DV tags from DGA tags.
+
+    Returns ``(tags, flag)`` where flag is ``'tag_fallback'`` when
+    the fallback tag is used.
+    """
+    names = [(t.get("name") or "").strip() for t in pkg.get("tags", [])]
+    names = [name for name in names if name]
+
+    if names:
+        return [{"name": name} for name in names], ""
+
+    return [{"name": TAG_FALLBACK}], "tag_fallback"
+
+
+def _resource_name(resource: dict) -> str:
+    """Return resource name, falling back to the URL basename."""
+    name = (resource.get("name") or "").strip()
+    if name:
+        return name
+    url = resource.get("url", "")
+    return os.path.basename(urlparse(url).path) or "resource"
+
+
+# ---------------------------------------------------------------------------
+# Helpers — CSV loading
+# ---------------------------------------------------------------------------
+
+def normalize_cell(value: str | None) -> str:
+    """Normalize a CSV cell value by removing common encoding artifacts.
+
+    Removes the following characters wherever they appear:
+    - \\u00a0: non-breaking space (NBSP)
+    - \\ufffd: Unicode replacement character (�)
+    - \\ufeff: byte order mark (BOM)
+
+    Also trims leading/trailing whitespace. Returns an empty string for None.
+    """
+    if not value:
+        return ""
+    for ch in "\u00a0\ufffd\ufeff":
+        value = value.replace(ch, "")
+    return value.strip()
+
+
+def _load_councils(csv_path: str) -> list[dict[str, str]]:
+    """Load council records from a CSV file and normalize all fields.
+
+    Applies ``normalize_cell`` to both column names and values to remove
+    encoding artifacts and trim whitespace.
+
+    Returns:
+        A list of dictionaries with cleaned keys and values
+        (e.g. Organisation, URL, Org Slug).
+    """
+    councils = []
+    with open(csv_path, newline="", encoding="utf-8-sig") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            clean = {normalize_cell(k): normalize_cell(v) for k, v in row.items()}
+            councils.append(clean)
+    return councils
+
+
+# ---------------------------------------------------------------------------
+# Helpers — audit CSV
+# ---------------------------------------------------------------------------
+
+
+def _make_report_path(report_dir: str) -> str:
+    ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    os.makedirs(report_dir, exist_ok=True)
+    return os.path.join(report_dir, f"datagov_migration_{ts}.csv")
+
+
+def _open_report(path: str):
+    """Open the audit CSV for writing; return (file_handle, DictWriter)."""
+    fh = open(path, "w", newline="", encoding="utf-8")
+    writer = csv.DictWriter(fh, fieldnames=_REPORT_COLUMNS)
+    writer.writeheader()
+    return fh, writer
+
+
+def _audit_row(
+    org_slug: str,
+    stage: str,
+    dga_id: str,
+    dv_id: str,
+    name: str,
+    status: str,
+    reason: str = "",
+    flags: list[str] | None = None,
+) -> dict:
+    return {
+        "org_slug": org_slug,
+        "stage": stage,
+        "dga_id": dga_id,
+        "dv_id": dv_id,
+        "name": name,
+        "status": status,
+        "reason": reason,
+        "flags": "; ".join(flags or []),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers — DGA payload JSON capture
+# ---------------------------------------------------------------------------
+
+
+def _save_payload_json(data: list | dict, backup_dir: str, filename: str) -> str:
+    """Save data as JSON and return the file path.
+
+    Uses default=str for json.dump to handle datetime and other non-serializable objects.
+    """
+    os.makedirs(backup_dir, exist_ok=True)
+    filepath = os.path.join(backup_dir, filename)
+    with open(filepath, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, default=str)
+    return filepath
+
+
+def _make_backup_run_dir(backup_dir: str) -> str:
+    """Create a timestamped backup directory for this migration run."""
+    ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    path = os.path.join(backup_dir, ts)
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def _safe_filename_part(value: str) -> str:
+    """Return a filesystem-safe token for JSON capture filenames."""
+    return re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-") or "unknown"
+
+
+# ---------------------------------------------------------------------------
+# CKAN action context
+# ---------------------------------------------------------------------------
+
+
+def _site_context() -> dict:
+    """Return a CKAN action context using the site user (bypasses auth).
+
+    CKAN's create actions (organization_create, package_create) require a
+    valid ``user`` in the context even when ``ignore_auth`` is True — they
+    use it to record the creator.  ``get_site_user`` creates the site user
+    on first call if it doesn't exist yet.
+    """
+    site_user = tk.get_action("get_site_user")({"ignore_auth": True}, {})
+    return {"ignore_auth": True, "user": site_user["name"]}
+
+
+def _dv_org_exists(org_id: str) -> bool:
+    try:
+        tk.get_action("organization_show")(_site_context(), {"id": org_id})
+        return True
+    except tk.ObjectNotFound:
+        return False
+
+
+def _dv_dataset_exists(dataset_id: str) -> bool:
+    try:
+        tk.get_action("package_show")(_site_context(), {"id": dataset_id})
+        return True
+    except tk.ObjectNotFound:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Migration steps
+# ---------------------------------------------------------------------------
+
+
+def _migrate_org(
+    client: ckanapi.RemoteCKAN,
+    slug: str,
+    backup_run_dir: str,
+    writer: csv.DictWriter,
+    counters: dict,
+) -> tuple[str, str] | None:
+    """Migrate a single org (AC1). Returns the DV (org_id, org_email), or None on failure."""
+    try:
+        dga_org = dga.org_show(client, slug)
+    except Exception as exc:
+        log.error("Failed to fetch org %r from DGA: %s", slug, exc)
+        writer.writerow(_audit_row(slug, "org", "", "", slug, "failed", str(exc)))
+        counters["org_failed"] += 1
+        return None
+
+    try:
+        safe_slug = _safe_filename_part(slug)
+        filepath = _save_payload_json(dga_org, backup_run_dir, f"org_{safe_slug}.json")
+        log.info("Saved DGA org_show payload to %s", filepath)
+    except Exception as exc:
+        log.warning("Failed to save org_show payload for %s: %s", slug, exc)
+
+    dga_id = dga_org["id"]
+    dga_org_email = (dga_org.get("email") or "").strip()
+
+    if _dv_org_exists(dga_id):
+        click.secho(f"  org {slug}: already exists on DV — skipping create", fg="yellow")
+        writer.writerow(_audit_row(slug, "org", dga_id, dga_id, slug, "skipped"))
+        counters["org_skipped"] += 1
+        return dga_id, dga_org_email
+
+    # Build org payload
+    org_data: dict[str, Any] = {
+        "id": dga_id,
+        "name": dga_org["name"],
+        "title": dga_org.get("title", ""),
+        "description": dga_org.get("description", ""),
+    }
+
+    # Download and attach org image
+    image_url = dga_org.get("image_display_url") or dga_org.get("image_url") or ""
+    tmp_path: str | None = None
+    image_upload_fh: Any = None
+
+    if image_url:
+        try:
+            with tempfile.NamedTemporaryFile(delete=False, suffix=_image_suffix(image_url)) as tmp:
+                tmp_path = tmp.name
+            dga.download_file(image_url, tmp_path, max_bytes=10 * 1024 * 1024)
+            image_upload_fh = open(tmp_path, "rb")
+            org_data["image_upload"] = image_upload_fh
+        except Exception as exc:
+            log.warning("Image download failed for %r (%s); creating org without image", slug, exc)
+            org_data.pop("image_upload", None)
+            if image_upload_fh:
+                try:
+                    image_upload_fh.close()
+                except Exception:
+                    pass
+
+    try:
+        tk.get_action("organization_create")(_site_context(), org_data)
+    finally:
+        if image_upload_fh:
+            try:
+                image_upload_fh.close()
+            except Exception:
+                pass
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except Exception:
+                pass
+
+    click.secho(f"  org {slug}: created (id={dga_id})", fg="green")
+    writer.writerow(_audit_row(slug, "org", dga_id, dga_id, slug, "created"))
+    counters["org_created"] += 1
+
+    return dga_id, dga_org_email
+
+
+def _image_suffix(url: str) -> str:
+    """Return a file extension (with dot) inferred from the URL, defaulting to .jpg."""
+    path = urlparse(url).path
+    _, ext = os.path.splitext(path)
+    return ext if ext else ".jpg"
+
+
+def _is_valid_email(value: str) -> bool:
+    value = (value or "").strip()
+    if not value:
+        return False
+
+    validator = tk.get_validator("email_validator")
+
+    try:
+        validator(value, {})
+        return True
+    except tk.Invalid:
+        return False
+
+
+def _is_valid_contact_point(value: str) -> bool:
+    """Return True when value is a valid email or HTTP(S) URL."""
+    value = (value or "").strip()
+    if not value:
+        return False
+    if _is_valid_email(value):
+        return True
+
+    try:
+        parsed = urlparse(value)
+    except (TypeError, ValueError):
+        return False
+    return parsed.scheme in ("http", "https") and bool(parsed.netloc)
+
+
+def _build_dataset_payload(
+    dga_pkg: dict,
+    dv_org_id: str,
+    dv_org_email: str,
+    flags_out: list[str],
+) -> dict[str, Any]:
+    """Map a DGA package dict to a DV package_create payload.
+
+    Populates ``flags_out`` in place with any audit flags encountered.
+    """
+    notes = dga_pkg.get("notes") or ""
+    extract = notes[:200]
+
+    tags, tag_flag = _build_tags(dga_pkg)
+    if tag_flag:
+        flags_out.append(tag_flag)
+
+    dga_license = dga_pkg.get("license_id") or ""
+    dv_license, lic_flag = _map_license(dga_license)
+    if lic_flag:
+        flags_out.append(lic_flag)
+
+    dv_freq, freq_flag = _map_frequency(dga_pkg)
+    if freq_flag:
+        flags_out.append(freq_flag)
+
+    date_created = dga_pkg.get("temporal_coverage_from") or ""
+    dga_name = dga_pkg.get("name") or ""
+
+    dga_contact_point = (dga_pkg.get("contact_point") or "").strip()
+    if _is_valid_contact_point(dga_contact_point):
+        contact_point = dga_contact_point
+    else:
+        contact_point = (dv_org_email or "").strip()
+        if contact_point and not _is_valid_contact_point(contact_point):
+            contact_point = ""
+        if dga_contact_point:
+            if contact_point:
+                flags_out.append("contact_point_not_email_org_email_used")
+            else:
+                flags_out.append("contact_point_not_email_no_fallback")
+
+    return {
+        "id": dga_pkg["id"],
+        "title": dga_pkg.get("title") or "",
+        "name": dga_name,
+        "notes": notes,
+        "extract": extract,
+        "tags": tags,
+        "owner_org": dv_org_id,
+        "license_id": dv_license,
+        "data_owner": dga_pkg.get("author") or "",
+        "contact_point": contact_point,
+        "date_created_data_asset": date_created,
+        "update_frequency": dv_freq,
+        "category": FIXED_CATEGORY,
+        "personal_information": FIXED_PERSONAL_INFO,
+        "private": False,
+    }
+
+
+def _package_name_exists(name: str) -> bool:
+    validator = tk.get_validator("package_name_exists")
+    try:
+        validator(name, {"model": model, "session": model.Session})
+        return True
+    except tk.Invalid:
+        return False
+
+
+def _next_available_package_name(base_name: str, max_suffix: int = 999) -> str:
+    base_name = re.sub(r"-+", "-", (base_name or "").strip()).strip("-")
+    if not base_name:
+        base_name = "dataset"
+
+    base_name = base_name[:PACKAGE_NAME_MAX_LENGTH]
+
+    if not _package_name_exists(base_name):
+        return base_name
+
+    for i in range(1, max_suffix + 1):
+        suffix = str(i)
+        candidate = base_name[: PACKAGE_NAME_MAX_LENGTH - len(suffix)] + suffix
+        if not _package_name_exists(candidate):
+            return candidate
+
+    # This is extremely unlikely, but if we exhaust all suffixes, return the base name.
+    return base_name
+
+
+def _migrate_dataset(
+    dga_pkg: dict,
+    dv_org_id: str,
+    dv_org_email: str,
+    org_slug: str,
+    writer: csv.DictWriter,
+    counters: dict,
+    max_filesize_bytes: int,
+) -> None:
+    """Migrate a single dataset and its resources (AC2, AC3, AC5)."""
+    dga_id = dga_pkg["id"]
+    dga_name = dga_pkg.get("name") or dga_id
+
+    # AC5: skip if already on DV
+    if _dv_dataset_exists(dga_id):
+        writer.writerow(_audit_row(org_slug, "dataset", dga_id, dga_id, dga_name, "skipped"))
+        counters["dataset_skipped"] += 1
+        return
+
+    flags: list[str] = []
+    reason: str = ""
+    try:
+        payload = _build_dataset_payload(dga_pkg, dv_org_id, dv_org_email, flags)
+        original_name = payload["name"]
+        unique_name = _next_available_package_name(original_name)
+
+        if unique_name != original_name:
+            payload["name"] = unique_name
+            flags.append("name_collision_renamed")
+            reason = f"{original_name} -> {unique_name}"
+        
+        dv_pkg = tk.get_action("package_create")(_site_context(), payload)
+        dv_pkg_id = dv_pkg["id"]
+    except Exception as exc:
+        log.error("package_create failed for %r (%s): %s", dga_name, dga_id, exc)
+        writer.writerow(
+            _audit_row(org_slug, "dataset", dga_id, "", dga_name, "failed", str(exc), flags)
+        )
+        counters["dataset_failed"] += 1
+        return
+
+    writer.writerow(
+        _audit_row(org_slug, "dataset", dga_id, dv_pkg_id, dga_name, "created", reason, flags)
+    )
+    counters["dataset_created"] += 1
+
+    # Temporal fields for resource period_start / period_end
+    period_start = dga_pkg.get("temporal_coverage_from") or ""
+    period_end = dga_pkg.get("temporal_coverage_to") or ""
+
+    for resource in dga_pkg.get("resources", []):
+        _migrate_resource(
+            resource=resource,
+            dv_pkg_id=dv_pkg_id,
+            dga_pkg_id=dga_id,
+            org_slug=org_slug,
+            period_start=period_start,
+            period_end=period_end,
+            writer=writer,
+            counters=counters,
+            max_filesize_bytes=max_filesize_bytes,
+        )
+
+
+def _migrate_resource(
+    resource: dict,
+    dv_pkg_id: str,
+    dga_pkg_id: str,
+    org_slug: str,
+    period_start: str,
+    period_end: str,
+    writer: csv.DictWriter,
+    counters: dict,
+    max_filesize_bytes: int,
+) -> None:
+    """Migrate a single resource (AC3)."""
+    dga_res_id = resource.get("id") or ""
+    res_name = _resource_name(resource)
+    url = resource.get("url") or ""
+    dga_last_modified = (resource.get("last_modified") or "").strip()
+    flags: list[str] = []
+
+    base_payload: dict[str, Any] = {
+        "package_id": dv_pkg_id,
+        "name": res_name,
+        "description": resource.get("description") or "",
+        "format": resource.get("format") or "",
+        "release_date": (resource.get("created") or "")[:10],
+        "period_start": period_start,
+        "period_end": period_end,
+    }
+    if resource.get("size"):
+        base_payload["filesize"] = resource["size"]
+    # Preserve DGA's last_modified so that, after harvest back to DGA, the
+    # geoserver ingest gate sees source SHP/KML and generated WMS/WFS/KML/
+    # GeoJSON resources sharing a timestamp and skips re-ingest.
+    if dga_last_modified:
+        base_payload["last_modified"] = dga_last_modified
+
+    is_upload = resource.get("url_type") == "upload"
+
+    if is_upload and url:
+        # Check size before downloading
+        remote_size = dga.head_size(url)
+        if remote_size is not None and remote_size > max_filesize_bytes:
+            # Over cap — store DGA URL as-is
+            flags.append("over_cap")
+            _create_linked_resource(base_payload, url, dv_pkg_id, org_slug, dga_pkg_id, dga_res_id,
+                                    res_name, writer, counters, flags)
+            return
+
+        tmp_path: str | None = None
+        try:
+            with tempfile.NamedTemporaryFile(delete=False, suffix=_res_suffix(res_name)) as tmp:
+                tmp_path = tmp.name
+
+            dga.download_file(url, tmp_path, max_bytes=max_filesize_bytes)
+
+            with open(tmp_path, "rb") as upload_fh:
+                resource_payload = dict(base_payload)
+    
+                # CKAN expects file uploads as FileStorage objects in the payload.
+                resource_payload["upload"] = FileStorage(
+                    stream=upload_fh,
+                    filename=res_name,
+                    content_type="application/octet-stream",
+                )
+                dv_res = tk.get_action("resource_create")(_site_context(), resource_payload)
+            # CKAN's upload pipeline stamps last_modified to the upload time,
+            # overwriting whatever was in the create payload. Patch it back so
+            # the value carried in base_payload actually persists.
+            if dga_last_modified:
+                try:
+                    tk.get_action("resource_patch")(
+                        _site_context(),
+                        {"id": dv_res["id"], "last_modified": dga_last_modified},
+                    )
+                except Exception as exc:
+                    log.warning(
+                        "resource_patch (last_modified) failed for %r in pkg %s: %s",
+                        res_name, dga_pkg_id, exc,
+                    )
+                    flags.append("last_modified_patch_failed")
+            writer.writerow(
+                _audit_row(org_slug, "resource", dga_res_id, dv_res["id"], res_name,
+                           "created", "", flags)
+            )
+            counters["resource_uploaded"] += 1
+        except dga.FileTooLargeError:
+            flags.append("over_cap")
+            log.warning("Resource %r exceeded size cap mid-download; storing DGA URL", res_name)
+            _create_linked_resource(base_payload, url, dv_pkg_id, org_slug, dga_pkg_id, dga_res_id,
+                                    res_name, writer, counters, flags)
+        except Exception as exc:
+            log.error("resource upload failed for %r in pkg %s: %s", res_name, dga_pkg_id, exc)
+            writer.writerow(
+                _audit_row(org_slug, "resource", dga_res_id, "", res_name, "failed", str(exc), flags)
+            )
+            counters["resource_failed"] += 1
+        finally:
+            if tmp_path:
+                try:
+                    os.unlink(tmp_path)
+                except Exception:
+                    pass
+    else:
+        # Linked resource — pass URL through
+        flags.append("linked_resource")
+        _create_linked_resource(base_payload, url, dv_pkg_id, org_slug, dga_pkg_id, dga_res_id,
+                                res_name, writer, counters, flags)
+
+
+def _create_linked_resource(
+    base_payload: dict,
+    url: str,
+    dv_pkg_id: str,
+    org_slug: str,
+    dga_pkg_id: str,
+    dga_res_id: str,
+    res_name: str,
+    writer: csv.DictWriter,
+    counters: dict,
+    flags: list[str],
+) -> None:
+    """Create a resource on DV using an external URL (no upload)."""
+    try:
+        resource_payload = dict(base_payload)
+        resource_payload["url"] = url
+        dv_res = tk.get_action("resource_create")(_site_context(), resource_payload)
+        status = "kept-as-url" if "over_cap" in flags else "created"
+        writer.writerow(
+            _audit_row(org_slug, "resource", dga_res_id, dv_res["id"], res_name,
+                       status, "", flags)
+        )
+        counters["resource_linked"] += 1
+    except Exception as exc:
+        log.error("resource_create (linked) failed for %r in pkg %s: %s", res_name, dga_pkg_id, exc)
+        writer.writerow(
+            _audit_row(org_slug, "resource", dga_res_id, "", res_name, "failed", str(exc), flags)
+        )
+        counters["resource_failed"] += 1
+
+
+def _res_suffix(name: str) -> str:
+    _, ext = os.path.splitext(name)
+    return ext if ext else ""
+
+
+# ---------------------------------------------------------------------------
+# CLI command
+# ---------------------------------------------------------------------------
+
+
+@click.command("migrate-from-data-gov-au")
+@click.option(
+    "--org",
+    "org_slugs",
+    multiple=True,
+    metavar="SLUG",
+    help=(
+        "Org slug(s) to migrate. Repeatable. "
+        "If omitted, all 39 Victorian councils in the bundled CSV are migrated."
+    ),
+)
+@click.option(
+    "--max-filesize-mb",
+    default=100,
+    show_default=True,
+    type=int,
+    help="Files larger than this (MB) are stored as DGA URLs rather than re-uploaded.",
+)
+@click.option(
+    "--csv-path",
+    default=DEFAULT_CSV_PATH,
+    show_default=True,
+    type=click.Path(exists=True),
+    help="Path to the council list CSV. Override for local testing.",
+)
+@click.option(
+    "--report-dir",
+    default=DEFAULT_REPORT_DIR,
+    show_default=True,
+    help="Directory for the per-run audit CSV report.",
+)
+@click.option(
+    "--backup-dir",
+    default=DEFAULT_BACKUP_DIR,
+    show_default=True,
+    help="Directory for JSON backups of org and package payloads from data.gov.au.",
+)
+@click.pass_context
+def migrate_from_data_gov_au(
+    ctx: click.Context,
+    org_slugs: tuple[str, ...],
+    max_filesize_mb: int,
+    csv_path: str,
+    report_dir: str,
+    backup_dir: str,
+) -> None:
+    """Migrate Victorian local council orgs, datasets, and resources from data.gov.au to DataVic.
+
+    Reads from data.gov.au (DGA) via CKAN API and writes to the local DV instance
+    using CKAN actions.  Safe to re-run: existing DV datasets (matched by preserved
+    DGA id) are skipped (AC5).
+    """
+    click.secho("=== DataVic ← data.gov.au Council Migration ===\n", fg="cyan", bold=True)
+    sys.stdout.flush()
+
+    max_filesize_bytes = max_filesize_mb * 1024 * 1024
+
+    # Load council list
+    try:
+        councils = _load_councils(csv_path)
+    except Exception as exc:
+        click.secho(f"Failed to load council CSV from {csv_path!r}: {exc}", fg="red")
+        sys.exit(1)
+
+    # Filter to requested orgs if --org given
+    if org_slugs:
+        slug_set = {s.lower() for s in org_slugs}
+        councils = [c for c in councils if c.get("Org Slug", "").lower() in slug_set]
+        if not councils:
+            click.secho(
+                f"No matching councils found for slugs: {', '.join(org_slugs)}", fg="red"
+            )
+            sys.exit(1)
+
+    click.secho(f"Orgs to migrate: {len(councils)}", fg="blue")
+    click.secho(f"Max file size:   {max_filesize_mb} MB", fg="blue")
+    click.secho(f"Council CSV:     {csv_path}", fg="blue")
+    click.secho(f"Report dir:      {report_dir}", fg="blue")
+    backup_run_dir = _make_backup_run_dir(backup_dir)
+    click.secho(f"Backup dir:      {backup_run_dir}\n", fg="blue")
+    sys.stdout.flush()
+
+    report_path = _make_report_path(report_dir)
+    report_fh, writer = _open_report(report_path)
+
+    client = dga.get_dga_client()
+
+    counters: dict[str, int] = {
+        "org_created": 0,
+        "org_skipped": 0,
+        "org_failed": 0,
+        "dataset_created": 0,
+        "dataset_skipped": 0,
+        "dataset_failed": 0,
+        "resource_uploaded": 0,
+        "resource_linked": 0,
+        "resource_failed": 0,
+    }
+
+    try:
+        app = ctx.meta["flask_app"]
+        # Use test_request_context for CLI operations to provide Flask request context
+        # that plugins like fortify expect when creating/modifying organizations
+        with app.test_request_context():
+            # Set up the user context for plugins that expect toolkit.g.userobj
+            from ckan import model
+            site_user = tk.get_action("get_site_user")({"ignore_auth": True}, {})
+            tk.g.userobj = model.User.get(site_user["name"])
+            
+            for council in councils:
+                slug = council.get("Org Slug") or council.get("org_slug") or ""
+                if not slug:
+                    click.secho(f"  Skipping row with missing slug: {council}", fg="yellow")
+                    continue
+
+                click.secho(f"\n--- {slug} ---", fg="cyan", bold=True)
+                sys.stdout.flush()
+
+                org_result = _migrate_org(client, slug, backup_run_dir, writer, counters)
+                if org_result is None:
+                    click.secho(f"  Skipping datasets for {slug} (org migration failed)", fg="red")
+                    continue
+
+                dv_org_id, dv_org_email = org_result
+
+                dataset_count = 0
+                org_packages = list(dga.iter_org_packages(client, slug))
+
+                try:
+                    safe_slug = _safe_filename_part(slug)
+                    filepath = _save_payload_json(
+                        org_packages, backup_run_dir, f"datasets_{safe_slug}.json"
+                    )
+                    log.info(
+                        "Saved DGA iter_org_packages payload (%s packages) to %s",
+                        len(org_packages),
+                        filepath,
+                    )
+                except Exception as exc:
+                    log.warning("Failed to save iter_org_packages payload for %s: %s", slug, exc)
+
+                for dga_pkg in org_packages:
+                    dataset_count += 1
+
+                    if dataset_count % 50 == 0:
+                        click.secho(f"  ... {dataset_count} datasets processed", fg="blue")
+                        sys.stdout.flush()
+
+                    _migrate_dataset(
+                        dga_pkg=dga_pkg,
+                        dv_org_id=dv_org_id,
+                        dv_org_email=dv_org_email,
+                        org_slug=slug,
+                        writer=writer,
+                        counters=counters,
+                        max_filesize_bytes=max_filesize_bytes,
+                    )
+
+                click.secho(
+                    f"  {slug}: {dataset_count} dataset(s) processed",
+                    fg="green",
+                )
+                sys.stdout.flush()
+    finally:
+        report_fh.close()
+
+    # ---- Summary ------------------------------------------------------------
+    click.secho("\n=== Migration complete ===", fg="cyan", bold=True)
+    click.secho(f"  Orgs created:       {counters['org_created']}", fg="green")
+    click.secho(f"  Orgs skipped:       {counters['org_skipped']}", fg="yellow")
+    click.secho(f"  Orgs failed:        {counters['org_failed']}",
+                fg="red" if counters["org_failed"] else "green")
+    click.secho(f"  Datasets created:   {counters['dataset_created']}", fg="green")
+    click.secho(f"  Datasets skipped:   {counters['dataset_skipped']}", fg="yellow")
+    click.secho(f"  Datasets failed:    {counters['dataset_failed']}",
+                fg="red" if counters["dataset_failed"] else "green")
+    click.secho(f"  Resources uploaded: {counters['resource_uploaded']}", fg="green")
+    click.secho(f"  Resources linked:   {counters['resource_linked']}", fg="green")
+    click.secho(f"  Resources failed:   {counters['resource_failed']}",
+                fg="red" if counters["resource_failed"] else "green")
+    click.secho(f"\nAudit report: {report_path}", fg="green")
+    sys.stdout.flush()

--- a/ckanext/datavic_odp_schema/cli/reconcile.py
+++ b/ckanext/datavic_odp_schema/cli/reconcile.py
@@ -71,7 +71,7 @@ _REQUEST_TIMEOUT = 30  # seconds
 
 def _dd_package_search(
     dd_url: str, dd_api_key: str
-) -> tuple[set[str], set[str]]:
+) -> tuple[set[str], set[str], set[dict[str, str]]]:
     """Fetch all active DD dataset names and IDs via paginated package_search.
 
     Returns:
@@ -79,6 +79,7 @@ def _dd_package_search(
     """
     dd_names: set[str] = set()
     dd_ids: set[str] = set()
+    dd_syndicated_ids: dict[str, str] = {}
     rows = 1000
     start = 0
 
@@ -93,7 +94,7 @@ def _dd_package_search(
             ),
                 "rows": rows,
                 "start": start,
-                "fl": "id,name",
+                "fl": "id,name,extras_syndicated_id",
             },
             headers={"Authorization": dd_api_key},
             timeout=_REQUEST_TIMEOUT,
@@ -113,6 +114,7 @@ def _dd_package_search(
         for pkg in results:
             dd_names.add(pkg["name"])
             dd_ids.add(pkg["id"])
+            dd_syndicated_ids[pkg["name"]] = pkg.get("syndicated_id", "")
 
         start += rows
 
@@ -123,7 +125,7 @@ def _dd_package_search(
         )
         sys.stdout.flush()
 
-    return dd_names, dd_ids
+    return dd_names, dd_ids, dd_syndicated_ids
 
 
 def _get_extra(pkg: dict[str, Any], key: str) -> str | None:
@@ -151,11 +153,11 @@ def _dd_package_show(
     dd_url: str, dd_api_key: str, id_or_name: str
 ) -> dict[str, Any] | None:
     """Call DD package_show.
-    
+
     Returns:
         dict: Dataset found on DD.
         None: Dataset definitively not found (404 or unsuccessful response).
-    
+
     Raises:
         requests.RequestException: API error (network, timeout, server error).
             Caller should treat as "uncertain" status.
@@ -184,6 +186,7 @@ def _classify_datasets(
     dv_datasets: list[tuple[str, str, str, str]],
     dd_names: set[str],
     dd_ids: set[str],
+    dd_syndicated_ids: dict[str, str],
     dd_url: str,
     dd_api_key: str,
 ) -> list[dict[str, str]]:
@@ -198,8 +201,9 @@ def _classify_datasets(
     # Phase 1: batch name match (fast, covers ~95%).
     for dv_id, dv_name, dv_state, dv_owner_org in dv_datasets:
         if dv_name in dd_names:
+            dd_syndicated_id = dd_syndicated_ids.get(dv_name, "")
             results.append(
-                _row(dv_id, dv_name, dv_state, dv_owner_org, "matched", dv_name, "active", "keep")
+                _row(dv_id, dv_name, dv_state, dv_owner_org, "matched", dv_name, "active", dd_syndicated_id, "keep")
             )
         else:
             unmatched.append((dv_id, dv_name, dv_state, dv_owner_org))
@@ -220,6 +224,7 @@ def _classify_datasets(
         classification = "uncertain"
         dd_name = ""
         dd_state = ""
+        dd_syndicated_id = ""
         action = "skip"
 
         # Check by name first.
@@ -232,7 +237,7 @@ def _classify_datasets(
                 "DD error checking dataset %s by name: %s", dv_name, exc
             )
             results.append(
-                _row(dv_id, dv_name, dv_state, dv_owner_org, classification, dd_name, dd_state, action)
+                _row(dv_id, dv_name, dv_state, dv_owner_org, classification, dd_name, dd_state, dd_syndicated_id, action)
             )
             continue
 
@@ -240,6 +245,7 @@ def _classify_datasets(
             # Found by name — check syndication eligibility.
             dd_name = dd_pkg.get("name", "")
             dd_state = dd_pkg.get("state", "")
+            dd_syndicated_id = dd_pkg.get("syndicated_id", "")
             if _is_syndication_eligible(dd_pkg):
                 # Active, public, published, visibility=all — keep.
                 classification = "matched"
@@ -260,7 +266,7 @@ def _classify_datasets(
                     "DD error checking dataset %s by ID: %s", dv_id, exc
                 )
                 results.append(
-                    _row(dv_id, dv_name, dv_state, dv_owner_org, classification, dd_name, dd_state, action)
+                    _row(dv_id, dv_name, dv_state, dv_owner_org, classification, dd_name, dd_state, dd_syndicated_id, action)
                 )
                 continue
 
@@ -268,6 +274,7 @@ def _classify_datasets(
                 # Found by ID — name mismatch, dataset is valid on DD.
                 dd_name = dd_pkg_by_id.get("name", "")
                 dd_state = dd_pkg_by_id.get("state", "")
+                dd_syndicated_id = dd_pkg_by_id.get("syndicated_id", "")
                 classification = "dd_name_mismatch"
                 action = "keep"
             else:
@@ -276,7 +283,7 @@ def _classify_datasets(
                 action = "purge"
 
         results.append(
-            _row(dv_id, dv_name, dv_state, dv_owner_org, classification, dd_name, dd_state, action)
+            _row(dv_id, dv_name, dv_state, dv_owner_org, classification, dd_name, dd_state, dd_syndicated_id, action)
         )
 
     return results
@@ -290,6 +297,7 @@ def _row(
     classification: str,
     dd_name: str,
     dd_state: str,
+    dd_syndicated_id: str,
     action: str,
 ) -> dict[str, str]:
     return {
@@ -300,6 +308,7 @@ def _row(
         "classification": classification,
         "dd_name": dd_name,
         "dd_state": dd_state,
+        "dd_syndicated_id": dd_syndicated_id,
         "action": action,
         "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
     }
@@ -358,6 +367,7 @@ _CSV_COLUMNS = [
     "classification",
     "dd_name",
     "dd_state",
+    "dd_syndicated_id",
     "action",
     "timestamp",
 ]
@@ -415,7 +425,7 @@ def reconcile_datasets(do_purge: bool, csv_path: str | None) -> None:
     # ---- Fetch DD reference set -------------------------------------------
     click.secho("Fetching DD active dataset reference set...", fg="blue")
     sys.stdout.flush()
-    dd_names, dd_ids = _dd_package_search(dd_url, dd_api_key)
+    dd_names, dd_ids, dd_syndicated_ids = _dd_package_search(dd_url, dd_api_key)
     click.secho(
         f"  DD reference: {len(dd_names)} active datasets.\n", fg="green"
     )
@@ -438,7 +448,7 @@ def reconcile_datasets(do_purge: bool, csv_path: str | None) -> None:
     click.secho("Classifying DV datasets...", fg="blue")
     sys.stdout.flush()
     classified = _classify_datasets(
-        dv_datasets, dd_names, dd_ids, dd_url, dd_api_key
+        dv_datasets, dd_names, dd_ids, dd_syndicated_ids, dd_url, dd_api_key
     )
 
     # Tally classifications.
@@ -451,6 +461,14 @@ def reconcile_datasets(do_purge: bool, csv_path: str | None) -> None:
         count = tallies.get(cls_name, 0)
         colour = "green" if cls_name == "matched" else "yellow" if cls_name in ("dd_name_mismatch", "uncertain") else "red"
         click.secho(f"  {cls_name}: {count}", fg=colour)
+
+    no_syndicated_id = 0
+    for row in classified:
+        sid = (row.get("dd_syndicated_id") or "").strip()
+        if not sid:
+            no_syndicated_id += 1
+    click.secho(f"  datasets without dd_syndicated_id: {no_syndicated_id}", fg="red")
+
     sys.stdout.flush()
 
     # ---- CSV report -------------------------------------------------------

--- a/ckanext/datavic_odp_schema/cli/reconcile.py
+++ b/ckanext/datavic_odp_schema/cli/reconcile.py
@@ -23,7 +23,6 @@ import sys
 from typing import Any
 
 import click
-import requests
 from sqlalchemy import or_
 
 import ckan.model as model
@@ -32,108 +31,17 @@ from ckan.lib.search import clear as search_clear
 
 from ckanext.datastore.backend import get_all_resources_ids_in_datastore
 
+from . import dd_api
+
 log = logging.getLogger(__name__)
 
-# ---------------------------------------------------------------------------
-# Config helpers
-# ---------------------------------------------------------------------------
+# Re-export for callers that need config
+_dd_url = dd_api._dd_url
+_dd_api_key = dd_api._dd_api_key
+_get_extra = dd_api._get_extra
 
-_CFG_DD_URL = "ckanext.datavic_odp.reconciliation.dd_url"
-_CFG_DD_API_KEY = "ckanext.datavic_odp.reconciliation.dd_api_key"
-
-
-def _dd_url() -> str:
-    url = tk.config.get(_CFG_DD_URL, "").strip().rstrip("/")
-    if not url:
-        raise click.ClickException(
-            f"DD URL not configured.  Set {_CFG_DD_URL} in ckan.ini "
-            f"or the corresponding environment variable."
-        )
-    return url
-
-
-def _dd_api_key() -> str:
-    key = tk.config.get(_CFG_DD_API_KEY, "").strip()
-    if not key:
-        raise click.ClickException(
-            f"DD API key not configured.  Set {_CFG_DD_API_KEY} in ckan.ini "
-            f"or the corresponding environment variable."
-        )
-    return key
-
-
-# ---------------------------------------------------------------------------
-# DD API helpers
-# ---------------------------------------------------------------------------
-
-_REQUEST_TIMEOUT = 30  # seconds
-
-
-def _dd_package_search(
-    dd_url: str, dd_api_key: str
-) -> tuple[set[str], set[str], set[dict[str, str]]]:
-    """Fetch all active DD dataset names and IDs via paginated package_search.
-
-    Returns:
-        (dd_names, dd_ids) — two sets for fast lookup.
-    """
-    dd_names: set[str] = set()
-    dd_ids: set[str] = set()
-    dd_syndicated_ids: dict[str, str] = {}
-    rows = 1000
-    start = 0
-
-    while True:
-        resp = requests.get(
-            f"{dd_url}/api/3/action/package_search",
-            params={
-                "fq": (
-                "+state:active "
-                "+extras_workflow_status:published "
-                "+extras_organization_visibility:all"
-            ),
-                "rows": rows,
-                "start": start,
-                "fl": "id,name,extras_syndicated_id",
-            },
-            headers={"Authorization": dd_api_key},
-            timeout=_REQUEST_TIMEOUT,
-        )
-        resp.raise_for_status()
-        data = resp.json()
-
-        if not data.get("success"):
-            raise click.ClickException(
-                f"DD package_search failed: {data.get('error', data)}"
-            )
-
-        results = data["result"]["results"]
-        if not results:
-            break
-
-        for pkg in results:
-            dd_names.add(pkg["name"])
-            dd_ids.add(pkg["id"])
-            dd_syndicated_ids[pkg["name"]] = pkg.get("syndicated_id", "")
-
-        start += rows
-
-        click.secho(
-            f"  Fetched {start} DD datasets so far "
-            f"(total: {data['result']['count']})...",
-            fg="blue",
-        )
-        sys.stdout.flush()
-
-    return dd_names, dd_ids, dd_syndicated_ids
-
-
-def _get_extra(pkg: dict[str, Any], key: str) -> str | None:
-    """Extract an extra value from a CKAN package dict."""
-    for extra in pkg.get("extras", []):
-        if extra.get("key") == key:
-            return extra.get("value")
-    return None
+# Default directory for reconciliation CSV (when --csv-path not set). Adjust as needed.
+DEFAULT_RECONCILIATION_CSV_DIR = "/app/filestore/purge_reports"
 
 
 def _is_syndication_eligible(pkg: dict[str, Any]) -> bool:
@@ -147,34 +55,6 @@ def _is_syndication_eligible(pkg: dict[str, Any]) -> bool:
     wf = _get_extra(pkg, "workflow_status")
     ov = _get_extra(pkg, "organization_visibility")
     return wf == "published" and ov == "all"
-
-
-def _dd_package_show(
-    dd_url: str, dd_api_key: str, id_or_name: str
-) -> dict[str, Any] | None:
-    """Call DD package_show.
-
-    Returns:
-        dict: Dataset found on DD.
-        None: Dataset definitively not found (404 or unsuccessful response).
-
-    Raises:
-        requests.RequestException: API error (network, timeout, server error).
-            Caller should treat as "uncertain" status.
-    """
-    resp = requests.get(
-        f"{dd_url}/api/3/action/package_show",
-        params={"id": id_or_name},
-        headers={"Authorization": dd_api_key},
-        timeout=_REQUEST_TIMEOUT,
-    )
-    if resp.status_code == 404:
-        return None
-    resp.raise_for_status()
-    data = resp.json()
-    if data.get("success"):
-        return data["result"]
-    return None
 
 
 # ---------------------------------------------------------------------------
@@ -202,8 +82,9 @@ def _classify_datasets(
     for dv_id, dv_name, dv_state, dv_owner_org in dv_datasets:
         if dv_name in dd_names:
             dd_syndicated_id = dd_syndicated_ids.get(dv_name, "")
+            sid_ok = _check_syndicated_id(dv_id, dv_name, dd_syndicated_id)
             results.append(
-                _row(dv_id, dv_name, dv_state, dv_owner_org, "matched", dv_name, "active", dd_syndicated_id, "keep")
+                _row(dv_id, dv_name, dv_state, dv_owner_org, "matched", dv_name, "active", dd_syndicated_id, "keep", sid_ok)
             )
         else:
             unmatched.append((dv_id, dv_name, dv_state, dv_owner_org))
@@ -225,11 +106,12 @@ def _classify_datasets(
         dd_name = ""
         dd_state = ""
         dd_syndicated_id = ""
+        sid_ok = "unknown"
         action = "skip"
 
         # Check by name first.
         try:
-            dd_pkg = _dd_package_show(dd_url, dd_api_key, dv_name)
+            dd_pkg = dd_api.dd_package_show(dd_url, dd_api_key, dv_name)
         except Exception as exc:
             # Any error (network, JSON decode, unexpected) — can't
             # determine status, mark uncertain and move on.
@@ -237,7 +119,7 @@ def _classify_datasets(
                 "DD error checking dataset %s by name: %s", dv_name, exc
             )
             results.append(
-                _row(dv_id, dv_name, dv_state, dv_owner_org, classification, dd_name, dd_state, dd_syndicated_id, action)
+                _row(dv_id, dv_name, dv_state, dv_owner_org, classification, dd_name, dd_state, dd_syndicated_id, action, sid_ok)
             )
             continue
 
@@ -245,7 +127,7 @@ def _classify_datasets(
             # Found by name — check syndication eligibility.
             dd_name = dd_pkg.get("name", "")
             dd_state = dd_pkg.get("state", "")
-            dd_syndicated_id = dd_pkg.get("syndicated_id", "")
+            dd_syndicated_id = _get_extra(dd_pkg, "syndicated_id") or ""
             if _is_syndication_eligible(dd_pkg):
                 # Active, public, published, visibility=all — keep.
                 classification = "matched"
@@ -255,10 +137,11 @@ def _classify_datasets(
                 # (inactive/private/draft/restricted visibility).
                 classification = "dd_not_eligible"
                 action = "purge"
+            sid_ok = _check_syndicated_id(dv_id, dv_name, dd_syndicated_id)
         else:
             # Not found by name (404) — try by DV dataset ID.
             try:
-                dd_pkg_by_id = _dd_package_show(dd_url, dd_api_key, dv_id)
+                dd_pkg_by_id = dd_api.dd_package_show(dd_url, dd_api_key, dv_id)
             except Exception as exc:
                 # Any error — can't determine status, mark uncertain
                 # and move on.
@@ -266,27 +149,53 @@ def _classify_datasets(
                     "DD error checking dataset %s by ID: %s", dv_id, exc
                 )
                 results.append(
-                    _row(dv_id, dv_name, dv_state, dv_owner_org, classification, dd_name, dd_state, dd_syndicated_id, action)
+                    _row(dv_id, dv_name, dv_state, dv_owner_org, classification, dd_name, dd_state, dd_syndicated_id, action, sid_ok)
                 )
                 continue
 
             if dd_pkg_by_id:
-                # Found by ID — name mismatch, dataset is valid on DD.
+                # Found by DV ID — name mismatch, dataset exists on DD.
                 dd_name = dd_pkg_by_id.get("name", "")
                 dd_state = dd_pkg_by_id.get("state", "")
-                dd_syndicated_id = dd_pkg_by_id.get("syndicated_id", "")
+                dd_syndicated_id = _get_extra(dd_pkg_by_id, "syndicated_id") or ""
                 classification = "dd_name_mismatch"
                 action = "keep"
             else:
                 # Not found by name or ID (both returned 404) — confirmed orphan.
                 classification = "orphan"
                 action = "purge"
+            sid_ok = _check_syndicated_id(dv_id, dv_name, dd_syndicated_id)
 
         results.append(
-            _row(dv_id, dv_name, dv_state, dv_owner_org, classification, dd_name, dd_state, dd_syndicated_id, action)
+            _row(dv_id, dv_name, dv_state, dv_owner_org, classification, dd_name, dd_state, dd_syndicated_id, action, sid_ok)
         )
 
     return results
+
+
+def _check_syndicated_id(dv_id: str, dv_name: str, dd_syndicated_id: str) -> str:
+    """Return 'yes', 'no', or 'unknown' for the syndicated_id equality check.
+
+    'unknown' means DD has no syndicated_id set (can't verify either way).
+    'no' is logged as a warning with a ready-to-run SQL fix for DD.
+    """
+    if not dd_syndicated_id:
+        return "unknown"
+    if dd_syndicated_id == dv_id:
+        return "yes"
+    log.warning(
+        "syndicated_id mismatch for %s: DD has %r but DV id is %r. "
+        "To fix on DD run:\n"
+        "  UPDATE package_extra SET value = '%s'\n"
+        "  WHERE key = 'syndicated_id'\n"
+        "    AND package_id = (SELECT id FROM package WHERE name = '%s');",
+        dv_name,
+        dd_syndicated_id,
+        dv_id,
+        dv_id,
+        dv_name,
+    )
+    return "no"
 
 
 def _row(
@@ -299,6 +208,7 @@ def _row(
     dd_state: str,
     dd_syndicated_id: str,
     action: str,
+    syndicated_id_ok: str = "unknown",
 ) -> dict[str, str]:
     return {
         "dv_id": dv_id,
@@ -309,6 +219,7 @@ def _row(
         "dd_name": dd_name,
         "dd_state": dd_state,
         "dd_syndicated_id": dd_syndicated_id,
+        "syndicated_id_ok": syndicated_id_ok,
         "action": action,
         "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
     }
@@ -368,6 +279,7 @@ _CSV_COLUMNS = [
     "dd_name",
     "dd_state",
     "dd_syndicated_id",
+    "syndicated_id_ok",
     "action",
     "timestamp",
 ]
@@ -403,7 +315,7 @@ def _write_csv(rows: list[dict[str, str]], path: str) -> None:
     default=None,
     type=click.Path(),
     help="Path for the CSV audit report.  Defaults to "
-    "/app/filestore/purge_reports/dv_reconciliation_<timestamp>.csv",
+    "<DEFAULT_RECONCILIATION_CSV_DIR>/dv_reconciliation_<timestamp>.csv",
 )
 def reconcile_datasets(do_purge: bool, csv_path: str | None) -> None:
     """Reconcile DV datasets against the DD source of truth.
@@ -425,7 +337,13 @@ def reconcile_datasets(do_purge: bool, csv_path: str | None) -> None:
     # ---- Fetch DD reference set -------------------------------------------
     click.secho("Fetching DD active dataset reference set...", fg="blue")
     sys.stdout.flush()
-    dd_names, dd_ids, dd_syndicated_ids = _dd_package_search(dd_url, dd_api_key)
+    dd_packages = dd_api.fetch_dd_active_packages(dd_url, dd_api_key)
+    dd_names = {p["name"] for p in dd_packages}
+    dd_ids = {p["id"] for p in dd_packages}
+    dd_syndicated_ids = {
+        p["name"]: (_get_extra(p, "syndicated_id") or "")
+        for p in dd_packages
+    }
     click.secho(
         f"  DD reference: {len(dd_names)} active datasets.\n", fg="green"
     )
@@ -439,6 +357,7 @@ def reconcile_datasets(do_purge: bool, csv_path: str | None) -> None:
             model.Package.id, model.Package.name, model.Package.state, model.Package.owner_org
         )
         .filter(model.Package.type == "dataset")
+        .filter(model.Package.state == "active")
         .all()
     )
     click.secho(f"  DV local: {len(dv_datasets)} datasets.\n", fg="green")
@@ -462,20 +381,34 @@ def reconcile_datasets(do_purge: bool, csv_path: str | None) -> None:
         colour = "green" if cls_name == "matched" else "yellow" if cls_name in ("dd_name_mismatch", "uncertain") else "red"
         click.secho(f"  {cls_name}: {count}", fg=colour)
 
-    no_syndicated_id = 0
-    for row in classified:
-        sid = (row.get("dd_syndicated_id") or "").strip()
-        if not sid:
-            no_syndicated_id += 1
-    click.secho(f"  datasets without dd_syndicated_id: {no_syndicated_id}", fg="red")
+    sid_yes = sum(1 for r in classified if r.get("syndicated_id_ok") == "yes")
+    sid_no = sum(1 for r in classified if r.get("syndicated_id_ok") == "no")
+    sid_unknown = sum(1 for r in classified if r.get("syndicated_id_ok") == "unknown")
+    click.secho("\nsyndicated_id verification:", fg="cyan", bold=True)
+    click.secho(f"  ok (matches dv_id):      {sid_yes}", fg="green")
+    click.secho(f"  mismatch (wrong dv_id):  {sid_no}", fg="red")
+    click.secho(f"  unknown (not set on DD): {sid_unknown}", fg="yellow")
+    if sid_no:
+        click.secho(
+            "\n  Mismatched datasets have a stale syndicated_id on DD pointing at an\n"
+            "  old DV dataset id (e.g. after a purge + re-create on DV).\n"
+            "  Fix each one on DD with (check the WARNING lines above for the exact SQL):\n"
+            "    UPDATE package_extra SET value = '<new_dv_id>'\n"
+            "    WHERE key = 'syndicated_id'\n"
+            "      AND package_id = (SELECT id FROM package WHERE name = '<dd_name>');\n"
+            "  Then rebuild the Solr index for that package on DD:\n"
+            "    ckan -c $CKAN_INI search-index rebuild <dd_package_id>",
+            fg="yellow",
+        )
 
     sys.stdout.flush()
 
     # ---- CSV report -------------------------------------------------------
     if not csv_path:
         ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-        csv_path = (
-            f"/app/filestore/purge_reports/dv_reconciliation_{ts}.csv"
+        csv_path = os.path.join(
+            DEFAULT_RECONCILIATION_CSV_DIR.rstrip("/"),
+            f"dv_reconciliation_{ts}.csv",
         )
     _write_csv(classified, csv_path)
 

--- a/ckanext/datavic_odp_schema/cli/sync_from_dd.py
+++ b/ckanext/datavic_odp_schema/cli/sync_from_dd.py
@@ -1,0 +1,340 @@
+"""Sync selected fields from DD to DV for datasets linked via DD's syndicated_id.
+
+Writes directly to ``package_extra`` / ``package`` table — no activity history,
+no ``metadata_modified`` bump, no plugin hooks fired.
+
+Run ``ckan -c $CKAN_INI search-index rebuild`` after the migration to update Solr.
+
+Fields synced
+-------------
+Extras (package_extra):
+  category, personal_information, data_owner, custom_licence_link
+
+Core package column:
+  maintainer_email
+"""
+
+from __future__ import annotations
+
+import csv
+import datetime
+import logging
+import os
+import sys
+import uuid
+from typing import Any
+
+import click
+
+import ckan.model as model
+
+from . import dd_api
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Field lists
+# ---------------------------------------------------------------------------
+
+# Fields stored as package_extra rows on both DD and DV.
+EXTRA_SYNC_FIELDS: list[str] = [
+    "category",
+    "personal_information",
+    "data_owner",
+    "custom_licence_link",
+]
+
+# Core CKAN package table columns to sync (not extras).
+CORE_SYNC_FIELDS: list[str] = [
+    "maintainer_email",
+]
+
+SYNC_FIELDS: list[str] = EXTRA_SYNC_FIELDS + CORE_SYNC_FIELDS
+
+DEFAULT_SYNC_REPORT_DIR = "/app/filestore/sync_syndicated_reports"
+
+_REPORT_COLUMNS = ["dv_id", "dv_name", "action"] + SYNC_FIELDS + ["warnings"]
+
+
+def _get_field(pkg: dict[str, Any], key: str) -> str:
+    """Return a non-empty field value from a package dict, or empty string."""
+    return dd_api._get_extra(pkg, key) or ""
+
+
+def _resolve_category(
+    category_id: str,
+    dv_category_ids: set[str],
+) -> tuple[str, str]:
+    """Resolve a DD category UUID to a DV group UUID.
+
+    Returns ``(resolved_id, warning)``.  ``warning`` is empty on success.
+
+    DD and DV share group UUIDs, so a direct match is expected for all datasets.
+    """
+    if category_id in dv_category_ids:
+        return category_id, ""
+    return "", f"category UUID {category_id!r} not found on DV"
+
+
+# ---------------------------------------------------------------------------
+# Direct DB write helpers
+# ---------------------------------------------------------------------------
+
+
+def _upsert_extra(
+    session: Any, package_id: str, key: str, value: str
+) -> str:
+    """Upsert a ``package_extra`` row. Returns ``'inserted'``, ``'updated'``, or ``'unchanged'``."""
+    existing = (
+        session.query(model.PackageExtra)
+        .filter_by(package_id=package_id, key=key)
+        .first()
+    )
+    if existing:
+        if existing.value == value and existing.state == "active":
+            return "unchanged"
+        existing.value = value
+        existing.state = "active"
+        return "updated"
+    session.add(
+        model.PackageExtra(
+            id=str(uuid.uuid4()),
+            package_id=package_id,
+            key=key,
+            value=value,
+            state="active",
+        )
+    )
+    return "inserted"
+
+
+def _update_core_field(
+    session: Any, package_id: str, field: str, value: str
+) -> str:
+    """Update a core ``package`` column. Returns ``'updated'`` or ``'unchanged'``."""
+    pkg = session.query(model.Package).filter_by(id=package_id).first()
+    if pkg is None:
+        return "unchanged"
+    current = getattr(pkg, field, None) or ""
+    if current == value:
+        return "unchanged"
+    setattr(pkg, field, value)
+    return "updated"
+
+
+# ---------------------------------------------------------------------------
+# Report helpers
+# ---------------------------------------------------------------------------
+
+
+def _report_row(
+    dv_id: str,
+    dv_name: str,
+    action: str,
+    values: dict[str, str],
+    warnings: list[str],
+) -> dict[str, str]:
+    row: dict[str, str] = {
+        "dv_id": dv_id,
+        "dv_name": dv_name,
+        "action": action,
+        "warnings": "; ".join(warnings),
+    }
+    for f in SYNC_FIELDS:
+        row[f] = values.get(f, "")
+    return row
+
+
+def _write_report(rows: list[dict[str, str]], path: str) -> None:
+    csv_dir = os.path.dirname(path)
+    if csv_dir:
+        os.makedirs(csv_dir, exist_ok=True)
+    with open(path, "w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=_REPORT_COLUMNS)
+        writer.writeheader()
+        writer.writerows(rows)
+    click.secho(f"\nReport written to: {path}", fg="green")
+
+
+# ---------------------------------------------------------------------------
+# CLI command
+# ---------------------------------------------------------------------------
+
+
+@click.command("sync-syndicated-fields")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Report what would be written without making any DB changes.",
+)
+@click.option(
+    "--report-path",
+    default=None,
+    type=click.Path(),
+    help=(
+        "Path for the CSV report. "
+        "Defaults to <DEFAULT_SYNC_REPORT_DIR>/sync_syndicated_fields_<timestamp>.csv."
+    ),
+)
+def sync_syndicated_fields(dry_run: bool, report_path: str | None) -> None:
+    """Sync fields from DD to DV for datasets linked via DD's syndicated_id.
+
+    Writes directly to ``package_extra`` / ``package`` table — no activity
+    history, no ``metadata_modified`` update, no plugin hooks.
+
+    After running, rebuild the Solr index:
+
+        ckan -c $CKAN_INI search-index rebuild
+
+    Fields synced: category, personal_information, data_owner,
+    custom_licence_link, maintainer_email.
+    """
+    mode = "DRY-RUN" if dry_run else "SYNC"
+    click.secho(f"=== Sync syndicated fields from DD [{mode}] ===\n", fg="cyan", bold=True)
+    sys.stdout.flush()
+
+    dd_url = dd_api._dd_url()
+    dd_key = dd_api._dd_api_key()
+    click.secho(f"DD URL: {dd_url}\n", fg="blue")
+    sys.stdout.flush()
+
+    # ---- Fetch DD active packages ----------------------------------------
+    click.secho("Fetching DD active datasets...", fg="blue")
+    sys.stdout.flush()
+    dd_packages = dd_api.fetch_dd_active_packages(dd_url, dd_key)
+
+    # Keyed by DV package UUID (DD's syndicated_id extra).
+    dd_by_dv_id: dict[str, dict[str, Any]] = {}
+    for pkg in dd_packages:
+        sid = _get_field(pkg, "syndicated_id")
+        if sid:
+            dd_by_dv_id[sid] = pkg
+
+    click.secho(
+        f"  {len(dd_packages)} active DD datasets; "
+        f"{len(dd_by_dv_id)} with syndicated_id.\n",
+        fg="green",
+    )
+    sys.stdout.flush()
+
+    # ---- Load DV category groups for resolution --------------------------
+    dv_groups = list(model.Group.all("group"))
+    dv_category_ids = {g.id for g in dv_groups}
+    click.secho(f"DV categories (groups): {len(dv_category_ids)} available.\n", fg="blue")
+    sys.stdout.flush()
+
+    # ---- Load all DV datasets --------------------------------------------
+    # No state filter — the DD-side query already restricts to active+published
+    # packages, so dd_by_dv_id only contains UUIDs for active DD datasets.
+    # Including non-active DV datasets ensures fields are populated even for
+    # deleted/draft datasets that may be restored later.
+    click.secho("Loading DV datasets...", fg="blue")
+    sys.stdout.flush()
+    dv_rows = (
+        model.Session.query(model.Package.id, model.Package.name)
+        .filter(model.Package.type == "dataset")
+        .all()
+    )
+    to_sync = [(dv_id, dv_name) for dv_id, dv_name in dv_rows if dv_id in dd_by_dv_id]
+    click.secho(
+        f"  {len(dv_rows)} DV datasets; {len(to_sync)} linked to DD.\n",
+        fg="green",
+    )
+    sys.stdout.flush()
+
+    if not to_sync:
+        click.secho("Nothing to sync.\n", fg="green")
+        sys.stdout.flush()
+        return
+
+    # ---- Sync loop -------------------------------------------------------
+    report_rows: list[dict[str, str]] = []
+    counters = {"updated": 0, "skipped": 0, "error": 0}
+
+    for i, (dv_id, dv_name) in enumerate(to_sync):
+        dd_pkg = dd_by_dv_id[dv_id]
+        values: dict[str, str] = {}
+        warnings: list[str] = []
+
+        # Resolve each field value from the DD package dict.
+        for f in EXTRA_SYNC_FIELDS:
+            if f == "category":
+                raw = _get_field(dd_pkg, "category")
+                if raw:
+                    resolved, warn = _resolve_category(raw, dv_category_ids)
+                    values["category"] = resolved
+                    if warn:
+                        warnings.append(warn)
+                else:
+                    values["category"] = ""
+            else:
+                values[f] = _get_field(dd_pkg, f)
+
+        for f in CORE_SYNC_FIELDS:
+            values[f] = _get_field(dd_pkg, f)
+
+        fields_to_write = {f: v for f, v in values.items() if v}
+
+        if not fields_to_write:
+            counters["skipped"] += 1
+            report_rows.append(_report_row(dv_id, dv_name, "skipped_no_values", values, warnings))
+            continue
+
+        if (i + 1) % 500 == 0:
+            click.secho(f"  Processing {i + 1}/{len(to_sync)}...", fg="blue")
+            sys.stdout.flush()
+
+        if dry_run:
+            parts = ", ".join(f"{f}={v!r}" for f, v in fields_to_write.items())
+            click.secho(f"  Would write {dv_name}: {parts}", fg="cyan")
+            report_rows.append(_report_row(dv_id, dv_name, "would_update", values, warnings))
+            counters["updated"] += 1
+            sys.stdout.flush()
+            continue
+
+        try:
+            for f, v in fields_to_write.items():
+                if f in EXTRA_SYNC_FIELDS:
+                    _upsert_extra(model.Session, dv_id, f, v)
+                else:
+                    _update_core_field(model.Session, dv_id, f, v)
+            model.Session.commit()
+            action = "updated"
+            counters["updated"] += 1
+        except Exception as exc:
+            model.Session.rollback()
+            action = "error"
+            counters["error"] += 1
+            warnings.append(str(exc))
+            log.error("Failed to write %s (%s): %s", dv_name, dv_id, exc)
+            click.secho(f"  ERROR {dv_name}: {exc}", fg="red")
+
+        report_rows.append(_report_row(dv_id, dv_name, action, values, warnings))
+
+    # ---- Summary ---------------------------------------------------------
+    click.secho("\n--- Summary ---", fg="cyan", bold=True)
+    click.secho(f"  Linked:   {len(to_sync)}", fg="blue")
+    click.secho(f"  Updated:  {counters['updated']}", fg="green")
+    click.secho(f"  Skipped:  {counters['skipped']}", fg="yellow")
+    click.secho(
+        f"  Errors:   {counters['error']}",
+        fg="red" if counters["error"] else "green",
+    )
+    if not dry_run:
+        click.secho(
+            "\nNext step — rebuild the Solr index to surface the new field values:\n"
+            "  ckan -c $CKAN_INI search-index rebuild",
+            fg="yellow",
+        )
+    sys.stdout.flush()
+
+    # ---- CSV report ------------------------------------------------------
+    if not report_path:
+        ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        report_path = os.path.join(
+            DEFAULT_SYNC_REPORT_DIR.rstrip("/"),
+            f"sync_syndicated_fields_{ts}.csv",
+        )
+    _write_report(report_rows, report_path)
+    sys.stdout.flush()

--- a/ckanext/datavic_odp_schema/cli/sync_from_dd.py
+++ b/ckanext/datavic_odp_schema/cli/sync_from_dd.py
@@ -8,7 +8,7 @@ Run ``ckan -c $CKAN_INI search-index rebuild`` after the migration to update Sol
 Fields synced
 -------------
 Extras (package_extra):
-  category, personal_information, data_owner, custom_licence_link
+  category, personal_information, data_owner, custom_licence_link, update_frequency
 
 Core package column:
   maintainer_email
@@ -42,6 +42,7 @@ EXTRA_SYNC_FIELDS: list[str] = [
     "personal_information",
     "data_owner",
     "custom_licence_link",
+    "update_frequency",
 ]
 
 # Core CKAN package table columns to sync (not extras).
@@ -188,7 +189,7 @@ def sync_syndicated_fields(dry_run: bool, report_path: str | None) -> None:
         ckan -c $CKAN_INI search-index rebuild
 
     Fields synced: category, personal_information, data_owner,
-    custom_licence_link, maintainer_email.
+    custom_licence_link, update_frequency, maintainer_email.
     """
     mode = "DRY-RUN" if dry_run else "SYNC"
     click.secho(f"=== Sync syndicated fields from DD [{mode}] ===\n", fg="cyan", bold=True)

--- a/ckanext/datavic_odp_schema/helpers.py
+++ b/ckanext/datavic_odp_schema/helpers.py
@@ -64,7 +64,7 @@ def date_str_to_timestamp(date: str) -> Optional[int]:
     """Parses date string and return it as a timestamp integer"""
     try:
         date_obj: datetime = parse_date(date)
-    except (ParserError, TypeError) as e:
+    except (ParserError, TypeError):
         return log.error("Error parsing date from %s", date)
 
     return int(date_obj.timestamp())
@@ -129,3 +129,21 @@ def localized_filesize(size_bytes: int) -> str:
     s = round(float(size_bytes) / p, 1)
 
     return f"{s} {size_name[i]}"
+
+
+def show_data_publisher_notice(pkg_dict: dict[str, Any]) -> bool:
+    """Return True to show the Data publisher notice on the dataset read page.
+
+    If ``vps_dataset`` is missing or blank, return False (no notice). If set to a
+    string CKAN can parse as true/false, show the notice when the value is false
+    for the VPS-lane policy. If the value is not a valid boolean string, return
+    False (no notice) so ``asbool`` does not raise on the read view.
+    """
+    vps_dataset = pkg_dict.get("vps_dataset")
+    if vps_dataset is None or str(vps_dataset).strip() == "":
+        return False
+    try:
+        return not tk.asbool(vps_dataset)
+    except ValueError:
+        return False
+

--- a/ckanext/datavic_odp_schema/helpers.py
+++ b/ckanext/datavic_odp_schema/helpers.py
@@ -5,6 +5,7 @@ import math
 
 from datetime import datetime
 from dateutil.parser import ParserError, parse as parse_date
+from sqlalchemy import func
 from typing import Any, Optional
 
 import ckan.model as model
@@ -91,6 +92,18 @@ def get_group(group: Optional[str] = None,
         )
     except (tk.NotFound, tk.ValidationError, tk.NotAuthorized):
         return {}
+
+
+def format_list() -> list[str]:
+    """Return a sorted list of unique, non-empty resource formats."""
+    cleaned_format = func.lower(func.trim(model.Resource.format))
+    query = (
+        model.Session.query(func.distinct(cleaned_format))
+        .filter(model.Resource.state == model.State.ACTIVE)
+        .filter(model.Resource.format.isnot(None))
+        .filter(model.Resource.format != "")
+    )
+    return sorted({fmt.upper().split(".")[-1] for (fmt,) in query})
 
 
 def localized_filesize(size_bytes: int) -> str:

--- a/ckanext/datavic_odp_schema/logic/validators.py
+++ b/ckanext/datavic_odp_schema/logic/validators.py
@@ -1,0 +1,52 @@
+"""Custom validators for ODP dataset schema."""
+
+import ckan.plugins.toolkit as tk
+
+from urllib.parse import urlparse
+from ckan.logic.validators import email_validator as ckan_email_validator
+from ckan.lib.navl.dictization_functions import Invalid
+
+
+def required_if_license_other(key, data, errors, context):
+    """
+    Require the current field to be non-empty when license_id is "other".
+    """
+    license_id = data.get(("license_id",))
+    if license_id is tk.missing or not license_id:
+        return
+
+    if str(license_id).strip().lower() != "other":
+        return
+
+    value = data.get(key)
+    if value is tk.missing or value is None or (isinstance(value, str) and not value.strip()):
+        errors[key].append(tk._("Missing value"))
+
+
+def url_email_validator(key, data, errors, context):
+    """
+    Validate that the value is non-empty and either a valid email or a valid URL.
+    """
+    value = data.get(key)
+    if value is tk.missing or value is None or (isinstance(value, str) and not value.strip()):
+        errors[key].append(tk._("Missing value"))
+        return
+
+    value = value.strip() if isinstance(value, str) else str(value).strip()
+
+    # Try to validate as email
+    try:
+        ckan_email_validator(value, context)
+        return
+    except Invalid:
+        pass
+
+    # Try to validate as URL
+    try:
+        parsed = urlparse(value)
+        if parsed.scheme and parsed.netloc and parsed.scheme in ("http", "https"):
+            return
+    except (ValueError, TypeError):
+        pass
+
+    errors[key].append(tk._("Must be a valid email address or URL"))

--- a/ckanext/datavic_odp_schema/logic/validators.py
+++ b/ckanext/datavic_odp_schema/logic/validators.py
@@ -25,11 +25,11 @@ def required_if_license_other(key, data, errors, context):
 
 def url_email_validator(key, data, errors, context):
     """
-    Validate that the value is non-empty and either a valid email or a valid URL.
+    Validate that the value, when provided, is a valid email or URL.
     """
     value = data.get(key)
     if value is tk.missing or value is None or (isinstance(value, str) and not value.strip()):
-        errors[key].append(tk._("Missing value"))
+        # Optional field: empty values are allowed.
         return
 
     value = value.strip() if isinstance(value, str) else str(value).strip()

--- a/ckanext/datavic_odp_schema/odp_dataset_schema.yaml
+++ b/ckanext/datavic_odp_schema/odp_dataset_schema.yaml
@@ -167,7 +167,7 @@ dataset_fields:
   form_snippet: text.html
   help_text: The team or individual responsible for managing this dataset.
 
-- field_name: maintainer_email
+- field_name: contact_point
   label: Point of contact
   form_placeholder: email
   validators: ignore_missing url_email_validator

--- a/ckanext/datavic_odp_schema/odp_dataset_schema.yaml
+++ b/ckanext/datavic_odp_schema/odp_dataset_schema.yaml
@@ -9,6 +9,7 @@ dataset_fields:
   label: Title
   preset: title
   form_placeholder: eg. A descriptive title
+  help_text: A meaningful and descriptive title for the dataset.
   required: true
 
 - field_name: name
@@ -18,16 +19,23 @@ dataset_fields:
 
 - field_name: alias
   preset: dataset_alias
+  help_text: If you update the DataVic URL after publishing, add the original value here to automatically redirect users.
 
 - field_name: notes
   label: Description
   form_snippet: markdown.html
   form_placeholder: eg. Some useful notes about the data
   required: true
+  help_text: Detailed description of the contents, purpose and structure of the dataset and how it was collected.
 
 - field_name: extract
-  form_snippet: null
-  display_snippet: null
+  label: Abstract
+  form_snippet: textarea.html
+  display_group: General
+  required: true
+  form_attrs:
+    maxlength: 200
+  help_text: Short description used by web crawlers to populate search engine indexes and help users discover the dataset.
 
 - field_name: tag_string
   label: Keywords
@@ -35,30 +43,52 @@ dataset_fields:
   form_snippet: tags.html
   form_placeholder: eg. economy, mental health, government
   required: true
+  help_text: Significant words, phrases or terms that represent the core topics of the dataset.
+
+- field_name: owner_org
+  label: Organization
+  preset: dataset_organization
+  required: true
+
+- field_name: category
+  label: Category
+  preset: select
+  display_group: General
+  choices_helper: category_list
+  required: true
+  form_include_blank_choice: true
 
 - field_name: license_id
   label: License
   form_snippet: license.html
-  help_text: License definitions and additional information can be found at http://opendefinition.org/
+  help_text: Select the relevant license that the dataset is being released under. Licensing your data for sharing, reuse and repurpose helps to ensure the appropriate attribution and conditions are applied.
   required: true
 
 - field_name: custom_licence_text
   label: License - other
   form_snippet: text.html
+  validators: ignore_missing required_if_license_other
+  help_text: If you selected 'Other (Open)', specify the applicable license.
 
-- field_name: owner_org
-  label: Organization
-  preset: dataset_organization
+- field_name: custom_licence_link
+  label: Custom license link
+  display_group: General
+  form_placeholder: Custom license link
+  form_snippet: text.html
+  validators: ignore_missing required_if_license_other
+  help_text: If you selected 'Other (Open)', provide a link to the applicable license.
 
 - field_name: date_created_data_asset
   label: Created (Data Asset)
   preset: date
   required: true
+  help_text: Date the dataset was first created or acquired (not the date of the metadata record was created on DataVic).
 
 - field_name: update_frequency
   label: Update Frequency
   preset: select
   display_group: General
+  required: true
   form_include_blank_choice: true
   choices:
     - value: continual
@@ -90,6 +120,7 @@ dataset_fields:
   label: Full Metadata URL
   display_group: General
   form_snippet: text.html
+  help_text: Provide a link to a complete metadata record, if available.
 
 - field_name: dtv_preview
   label: Digital Twin Preview
@@ -103,6 +134,41 @@ dataset_fields:
       label: "Off"
   validators: default(true) boolean_validator
   output_validators: boolean_validator
+  help_text: Suitable spatial datasets can be previewed on DataVic using Digital Twin Victoria.<br/>You can manually turn this off if required.
+  help_allow_html: true
+
+- field_name: personal_information
+  label: Personal information
+  preset: select
+  display_group: Security
+  required: true
+  form_include_blank_choice: true
+  choices:
+    - value: not_yet
+      label: Not yet assessed
+    - value: 'yes'
+      label: 'Yes'
+    - value: yes_de_identified
+      label: Yes - it has been de-identifie
+    - value: 'no'
+      label: 'No'
+  help_text: Does the dataset contain personal information or health information as defined by <a href="https://ovic.vic.gov.au/book/key-concepts" target="_blank">OVIC</a>?
+  help_allow_html: true
+
+- field_name: data_owner
+  label: Data Custodian
+  form_placeholder: Joe Bloggs
+  display_group: Custodian
+  form_snippet: text.html
+  help_text: The team or individual responsible for managing this dataset.
+
+- field_name: maintainer_email
+  label: Point of contact
+  form_placeholder: email
+  validators: ignore_missing url_email_validator
+  display_group: Custodian
+  form_snippet: text.html
+  help_text: Shared inbox or contact form for user queries e.g. https://data.melbourne.vic.gov.au/pages/contact_us_form/
 
 - field_name: nominated_view_id
   display_snippet: null
@@ -126,7 +192,7 @@ resource_fields:
   label: Description
   form_snippet: markdown.html
   form_placeholder: Some useful notes about the data
-  
+
 - field_name: format
   label: Format
   preset: resource_format_autocomplete
@@ -136,27 +202,33 @@ resource_fields:
 - field_name: filesize
   label: File Size
   display_snippet: filesize.html
+  validators: ignore_missing int_validator
 
 - field_name: release_date
   label: Release Date
   preset: date
+  help_text: Date the data resource was publicly released.
 
 - field_name: period_start
   label: Temporal Coverage Start
   preset: date
+  help_text: Start date of time period the data resource covers.
 
 - field_name: period_end
   label: Temporal Coverage End
   preset: date
+  help_text: End date of time period the data resource covers.
 
 - field_name: data_quality
   label: Data Quality Statement
-  form_snippet: textarea.html
+  form_snippet: markdown.html
   display_snippet: markdown.html
+  help_text: Describe the quality of the data resource and any disclaimers/limitations. Otherwise, link to a separate data quality statement
 
 - field_name: attribution
   label: Attribution Statement
   form_snippet: textarea.html
+  help_text: Helps users correctly attribute the data resource.
 
 - field_name: attributes
   label: Attributes

--- a/ckanext/datavic_odp_schema/odp_dataset_schema.yaml
+++ b/ckanext/datavic_odp_schema/odp_dataset_schema.yaml
@@ -183,6 +183,11 @@ dataset_fields:
   display_snippet: null
   form_snippet: vic_hidden.html
 
+- field_name: vps_dataset
+  display_snippet: null
+  form_snippet: vic_hidden.html
+  validators: default(false) boolean_validator
+
 resource_fields:
 
 - field_name: url

--- a/ckanext/datavic_odp_schema/odp_dataset_schema.yaml
+++ b/ckanext/datavic_odp_schema/odp_dataset_schema.yaml
@@ -11,15 +11,18 @@ dataset_fields:
   form_placeholder: eg. A descriptive title
   help_text: A meaningful and descriptive title for the dataset.
   required: true
+  validators: scheming_required
 
 - field_name: name
   label: URL
-  preset: dataset_alias_slug
+  form_snippet: slug.html
+  validators: not_empty unicode_safe name_validator package_name_validator name_doesnt_conflict_with_alias
   form_placeholder: eg. my-dataset
+  help_text: This URL is automatically generated based on the title and can be edited if required.
 
 - field_name: alias
   preset: dataset_alias
-  help_text: If you update the DataVic URL after publishing, add the original value here to automatically redirect users.
+  help_text: If you update the URL after publishing, add the original value here to automatically redirect users.
 
 - field_name: notes
   label: Description
@@ -43,6 +46,7 @@ dataset_fields:
   form_snippet: tags.html
   form_placeholder: eg. economy, mental health, government
   required: true
+  validators: datavic_tag_string_convert
   help_text: Significant words, phrases or terms that represent the core topics of the dataset.
 
 - field_name: owner_org
@@ -63,6 +67,7 @@ dataset_fields:
   form_snippet: license.html
   help_text: Select the relevant license that the dataset is being released under. Licensing your data for sharing, reuse and repurpose helps to ensure the appropriate attribution and conditions are applied.
   required: true
+  default: cc-by
 
 - field_name: custom_licence_text
   label: License - other
@@ -188,6 +193,7 @@ resource_fields:
   label: Name
   form_placeholder: eg. January 2011 Gold Prices
   required: true
+  validators: scheming_required
 
 - field_name: description
   label: Description
@@ -201,9 +207,9 @@ resource_fields:
   validators: if_empty_guess_format not_empty clean_format unicode_safe
 
 - field_name: filesize
-  label: File Size
+  label: File size (bytes)
   display_snippet: filesize.html
-  validators: ignore_missing int_validator
+  validators: ignore_missing datavic_filesize_validator
 
 - field_name: release_date
   label: Release Date

--- a/ckanext/datavic_odp_schema/odp_dataset_schema.yaml
+++ b/ckanext/datavic_odp_schema/odp_dataset_schema.yaml
@@ -149,7 +149,7 @@ dataset_fields:
     - value: 'yes'
       label: 'Yes'
     - value: yes_de_identified
-      label: Yes - it has been de-identifie
+      label: Yes - it has been de-identified
     - value: 'no'
       label: 'No'
   help_text: Does the dataset contain personal information or health information as defined by <a href="https://ovic.vic.gov.au/book/key-concepts" target="_blank">OVIC</a>?
@@ -187,6 +187,7 @@ resource_fields:
 - field_name: name
   label: Name
   form_placeholder: eg. January 2011 Gold Prices
+  required: true
 
 - field_name: description
   label: Description

--- a/ckanext/datavic_odp_schema/plugin.py
+++ b/ckanext/datavic_odp_schema/plugin.py
@@ -23,9 +23,11 @@ class DatavicODPSchema(p.SingletonPlugin):
     # IPackageController
     def after_dataset_show(self, context, pkg_dict):
         pkg_dict.pop("maintainer_email", None)
+        pkg_dict.pop("data_owner", None)
         return pkg_dict
 
     def after_dataset_search(self, search_results, search_params):
         for item in search_results.get("results", []):
             item.pop("maintainer_email", None)
+            item.pop("data_owner", None)
         return search_results

--- a/ckanext/datavic_odp_schema/plugin.py
+++ b/ckanext/datavic_odp_schema/plugin.py
@@ -22,10 +22,10 @@ class DatavicODPSchema(p.SingletonPlugin):
 
     # IPackageController
     def after_dataset_show(self, context, pkg_dict):
-        pkg_dict.pop("contact_point", None)
+        pkg_dict.pop("maintainer_email", None)
         return pkg_dict
 
     def after_dataset_search(self, search_results, search_params):
         for item in search_results.get("results", []):
-            item.pop("contact_point", None)
+            item.pop("maintainer_email", None)
         return search_results

--- a/ckanext/datavic_odp_schema/plugin.py
+++ b/ckanext/datavic_odp_schema/plugin.py
@@ -3,13 +3,13 @@ import logging
 import ckan.plugins as p
 import ckan.plugins.toolkit as tk
 
-
 log = logging.getLogger(__name__)
 
 
 @tk.blanket.blueprints
 @tk.blanket.cli
 @tk.blanket.helpers
+@tk.blanket.validators
 class DatavicODPSchema(p.SingletonPlugin):
     p.implements(p.IConfigurer)
 

--- a/ckanext/datavic_odp_schema/plugin.py
+++ b/ckanext/datavic_odp_schema/plugin.py
@@ -14,7 +14,18 @@ log = logging.getLogger(__name__)
 @tk.blanket.validators
 class DatavicODPSchema(p.SingletonPlugin):
     p.implements(p.IConfigurer)
+    p.implements(p.IPackageController, inherit=True)
 
     # IConfigurer
     def update_config(self, config_):
         tk.add_template_directory(config_, "templates")
+
+    # IPackageController
+    def after_dataset_show(self, context, pkg_dict):
+        pkg_dict.pop("contact_point", None)
+        return pkg_dict
+
+    def after_dataset_search(self, search_results, search_params):
+        for item in search_results.get("results", []):
+            item.pop("contact_point", None)
+        return search_results

--- a/ckanext/datavic_odp_schema/plugin.py
+++ b/ckanext/datavic_odp_schema/plugin.py
@@ -3,6 +3,8 @@ import logging
 import ckan.plugins as p
 import ckan.plugins.toolkit as tk
 
+from ckanext.datavic_odp_schema import validators
+
 log = logging.getLogger(__name__)
 
 

--- a/ckanext/datavic_odp_schema/templates/scheming/form_snippets/organization.html
+++ b/ckanext/datavic_odp_schema/templates/scheming/form_snippets/organization.html
@@ -2,9 +2,12 @@
 
 {% block package_metadata_fields_visibility %}
   <div class="control-group form-group control-medium">
-    <label for="field-private" class="control-label">{{ _('Visibility') }}</label>
+    <label for="field-private" class="control-label">
+      <span title="This field is required" class="control-required">*</span>
+      {{ _('Visibility') }}
+    </label>
     <div class="controls">
-      <select id="field-private" name="private" class="form-control form-select">
+      <select id="field-private" name="private" class="form-control">
         {% for option in [('True', _('Private')), ('False', _('Public'))] %}
         <option value="{{ option[0] }}" {% if option[0] == data.private|trim %}selected="selected"{% endif %}>{{ option[1] }}</option>
         {% endfor %}

--- a/ckanext/datavic_odp_schema/templates/scheming/form_snippets/organization.html
+++ b/ckanext/datavic_odp_schema/templates/scheming/form_snippets/organization.html
@@ -1,0 +1,18 @@
+{% ckan_extends %}
+
+{% block package_metadata_fields_visibility %}
+  <div class="control-group form-group control-medium">
+    <label for="field-private" class="control-label">{{ _('Visibility') }}</label>
+    <div class="controls">
+      <select id="field-private" name="private" class="form-control form-select">
+        {% for option in [('True', _('Private')), ('False', _('Public'))] %}
+        <option value="{{ option[0] }}" {% if option[0] == data.private|trim %}selected="selected"{% endif %}>{{ option[1] }}</option>
+        {% endfor %}
+      </select>
+      <div class="info-block ">
+        <i class="fa fa-info-circle"></i>
+        {{ _('Make the dataset available to the public or restrict it to members of your organisation.') }}
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/ckanext/datavic_odp_schema/templates/scheming/form_snippets/slug.html
+++ b/ckanext/datavic_odp_schema/templates/scheming/form_snippets/slug.html
@@ -1,0 +1,38 @@
+{% import 'macros/form.html' as form %}
+
+{% set read_endpoint = '.read' if h.check_ckan_version(min_version="2.9") else '_read' %}
+
+{%- if entity_type == 'dataset' %}
+    {%- set controller = 'package' -%}
+{%- elif entity_type == 'organization' %}
+    {%- set controller = 'organization' -%}
+{%- elif entity_type == 'group' -%}
+    {%- set controller = 'group' -%}
+{%- endif -%}
+
+{%- set module_placeholder = '<' + object_type + '>' -%}
+
+{%- set prefix = h.url_for(object_type + read_endpoint, id='') -%}
+{%- set domain = h.url_for(object_type + read_endpoint, id='', qualified=true) -%}
+{%- set domain = domain|replace("http://", "")|replace("https://", "") -%}
+{%- set module_name = 'datavic-slug-visible' if entity_type == 'dataset' else 'slug-preview-slug' -%}
+{%- set attrs = {
+    'class': 'form-control',
+    'data-module': module_name,
+    'data-module-prefix': domain,
+    'data-module-placeholder': module_placeholder } -%}
+
+{% call form.prepend(
+    field.field_name,
+    id='field-' + field.field_name,
+    label=h.scheming_language_text(field.label),
+    prepend=prefix,
+    placeholder=h.scheming_language_text(field.form_placeholder),
+    value=data[field.field_name],
+    error=errors[field.field_name],
+    attrs=attrs,
+    is_required=h.scheming_field_required(field)
+    )
+%}
+    {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
+{% endcall %}

--- a/ckanext/datavic_odp_schema/templates/scheming/package/read.html
+++ b/ckanext/datavic_odp_schema/templates/scheming/package/read.html
@@ -1,0 +1,9 @@
+{% ckan_extends %}
+
+{% block primary_content_inner %}
+  {{ super() }}
+
+  {% if h.show_data_publisher_notice(pkg) %}
+    {% snippet "scheming/package/snippets/data_publisher_notice.html", pkg_dict=pkg %}
+  {% endif %}
+{% endblock %}

--- a/ckanext/datavic_odp_schema/templates/scheming/package/snippets/additional_info.html
+++ b/ckanext/datavic_odp_schema/templates/scheming/package/snippets/additional_info.html
@@ -112,6 +112,13 @@
           <th scope="row" class="dataset-label">{{ _("Update Frequency") }}</th>
           <td class="dataset-details">{{ pkg_dict.update_frequency|capitalize }}</td>
         </tr>
+
+        {% if pkg_dict.contact_point %}
+          <tr>
+            <th scope="row" class="dataset-label">{{ _("Point of contact") }}</th>
+            <td class="dataset-details">{{ pkg_dict.contact_point }}</td>
+          </tr>
+        {% endif %}
       {% endblock %}
     </tbody>
   </table>

--- a/ckanext/datavic_odp_schema/templates/scheming/package/snippets/data_publisher_notice.html
+++ b/ckanext/datavic_odp_schema/templates/scheming/package/snippets/data_publisher_notice.html
@@ -1,0 +1,12 @@
+<section class="additional-info">
+  <h3>{{ _('Data source')}}</h3>
+
+  <p>
+    {% if pkg_dict.organization %}
+      <a href="{{ h.url_for('organization.read', id=pkg_dict.organization.name) }}">
+        {{ pkg_dict.organization.title or pkg_dict.organization.name }}
+      </a><br/>
+    {% endif %}
+    {{ _('Responsibility for legislative and policy compliance rests with the publisher.') }}
+  </p>
+</section>

--- a/ckanext/datavic_odp_schema/templates/scheming/package/snippets/resource_form.html
+++ b/ckanext/datavic_odp_schema/templates/scheming/package/snippets/resource_form.html
@@ -1,0 +1,11 @@
+{% ckan_extends %}
+
+{% import 'macros/form.html' as form %}
+
+{% block errors %}
+  {% if error_summary and not errors %}
+    {{ form.errors(error_summary) }}
+  {% else %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}

--- a/ckanext/datavic_odp_schema/tests/cli/test_migrate_from_dga.py
+++ b/ckanext/datavic_odp_schema/tests/cli/test_migrate_from_dga.py
@@ -1,0 +1,916 @@
+"""Tests for the data.gov.au → DataVic council migration command.
+
+Unit tests exercise the pure-Python mapping helpers without a CKAN stack.
+Integration tests use a CKAN test database (``clean_db`` fixture) and
+monkeypatch ``ckanapi.RemoteCKAN`` so no real DGA network calls are made.
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import click
+
+from ckanext.datavic_odp_schema.cli.migrate_from_dga import (
+    LICENSE_FALLBACK,
+    FREQUENCY_FALLBACK,
+    TAG_FALLBACK,
+    _load_councils,
+    _map_frequency,
+    _map_license,
+    _build_tags,
+    _build_dataset_payload,
+    _resource_name,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app_context(monkeypatch):
+    """Provide Flask app context for CLI tests by patching Click Context."""
+    from flask import Flask
+    from flask_babel import Babel
+
+    # Create a minimal Flask app for context management
+    app = Flask("test_app")
+    app.config["TESTING"] = True
+    Babel(app)
+
+    # Patch Click Context to always have the app in meta
+    original_init = click.Context.__init__
+
+    def patched_init(ctx_self, *args, **kwargs):
+        original_init(ctx_self, *args, **kwargs)
+        ctx_self.meta["flask_app"] = app
+
+    monkeypatch.setattr(click.Context, "__init__", patched_init)
+    yield app
+
+
+# ---------------------------------------------------------------------------
+# Unit — license mapping
+# ---------------------------------------------------------------------------
+
+
+class TestLicenseMap:
+    """Every DGA license_id in the ticket table must map to the correct DV value."""
+
+    @pytest.mark.parametrize(
+        "dga_id, expected_dv, expect_flag",
+        [
+            ("cc-by", "cc-by", ""),
+            ("cc-by-2.5", "cc-by", ""),
+            ("cc-by-4.0", "cc-by", ""),
+            ("cc-by-sa", "cc-by-sa", ""),
+            ("cc-nc", "cc-nc", ""),
+            ("other-nc", "cc-nc", ""),
+            ("other", "other", ""),
+            ("other-open", "other", ""),
+            ("other-forsale", "other", "license_unmapped"),
+            ("other-unpublished", "other", "license_unmapped"),
+            ("pdm", "other", "license_unmapped"),
+            ("oecd-data", "other", "license_unmapped"),
+            # Fallback cases
+            ("notspecified", LICENSE_FALLBACK, "license_fallback"),
+            ("", LICENSE_FALLBACK, "license_fallback"),
+        ],
+    )
+    def test_license_map(self, dga_id: str, expected_dv: str, expect_flag: str) -> None:
+        dv_license, flag = _map_license(dga_id)
+        assert dv_license == expected_dv, f"{dga_id!r} → expected {expected_dv!r}, got {dv_license!r}"
+        assert flag == expect_flag, f"{dga_id!r} → expected flag {expect_flag!r}, got {flag!r}"
+
+
+# ---------------------------------------------------------------------------
+# Unit — update-frequency mapping
+# ---------------------------------------------------------------------------
+
+
+class TestFrequencyMap:
+    """Frequency values must use schema enum casing (asNeeded, notPlanned)."""
+
+    @pytest.mark.parametrize(
+        "dga_val, expected_dv, expect_flag",
+        [
+            ("daily", "daily", ""),
+            ("weekly", "weekly", ""),
+            ("monthly", "monthly", ""),
+            ("quarterly", "quarterly", ""),
+            ("biannually", "biannually", ""),
+            ("annually", "annually", ""),
+            ("biennaully", "biannually", ""),   # DGA typo — maps to biannually
+            ("infrequently", "irregular", ""),
+            ("never", "notPlanned", ""),         # schema casing: notPlanned not notplanned
+            ("other", "unknown", ""),
+            ("", FREQUENCY_FALLBACK, "freq_fallback"),
+        ],
+    )
+    def test_frequency_map(self, dga_val: str, expected_dv: str, expect_flag: str) -> None:
+        pkg = {"extras": [{"key": "update_freq", "value": dga_val}]} if dga_val else {}
+        dv_val, flag = _map_frequency(pkg)
+        assert dv_val == expected_dv, f"{dga_val!r} → expected {expected_dv!r}, got {dv_val!r}"
+        assert flag == expect_flag
+
+    def test_frequency_absent_extra(self) -> None:
+        """When update_freq extra is absent the fallback is 'unknown'."""
+        dv_val, flag = _map_frequency({"extras": []})
+        assert dv_val == FREQUENCY_FALLBACK
+        assert flag == "freq_fallback"
+
+    def test_frequency_no_extras_key(self) -> None:
+        """When the package has no extras at all the fallback is 'unknown'."""
+        dv_val, flag = _map_frequency({})
+        assert dv_val == FREQUENCY_FALLBACK
+        assert flag == "freq_fallback"
+
+
+# ---------------------------------------------------------------------------
+# Unit — dataset field mapper
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDatasetPayload:
+    def _dga_pkg(self, **overrides) -> dict:
+        pkg: dict[str, Any] = {
+            "id": "dga-uuid-1234",
+            "name": "my-dataset",
+            "title": "My Dataset",
+            "notes": "A" * 300,
+            "tags": [{"name": "environment"}, {"name": "water"}],
+            "license_id": "cc-by",
+            "author": "Test Author",
+            "contact_point": "test@example.com",
+            "temporal_coverage_from": "2020-01-01",
+            "temporal_coverage_to": "2023-12-31",
+            "extras": [
+                {"key": "update_freq", "value": "monthly"},
+            ],
+            "resources": [],
+        }
+        pkg.update(overrides)
+        return pkg
+
+    def test_date_created_from_temporal_coverage_from(self) -> None:
+        """date_created_data_asset must come from temporal_coverage_from, not metadata_created."""
+        pkg = self._dga_pkg(
+            temporal_coverage_from="2019-06-01",
+            extras=[
+                {"key": "update_freq", "value": "monthly"},
+            ]
+        )
+        payload = _build_dataset_payload(pkg, "org-id-abc", "", [])
+        assert payload["date_created_data_asset"] == "2019-06-01"
+
+    def test_contact_point_from_email(self) -> None:
+        pkg = self._dga_pkg(contact_point="contact@council.vic.gov.au")
+        payload = _build_dataset_payload(pkg, "org-id-abc", "", [])
+        assert payload["contact_point"] == "contact@council.vic.gov.au"
+
+    def test_contact_point_from_url(self) -> None:
+        pkg = self._dga_pkg(contact_point="https://example.com/contact")
+        payload = _build_dataset_payload(pkg, "org-id-abc", "", [])
+        assert payload["contact_point"] == "https://example.com/contact"
+
+    def test_invalid_contact_point_falls_back_to_org_email(self) -> None:
+        flags: list[str] = []
+        pkg = self._dga_pkg(contact_point="not an email or url")
+        payload = _build_dataset_payload(pkg, "org-id-abc", "org@example.com", flags)
+        assert payload["contact_point"] == "org@example.com"
+        assert "contact_point_not_email_org_email_used" in flags
+
+    def test_extract_truncated_to_200(self) -> None:
+        long_notes = "B" * 500
+        pkg = self._dga_pkg(notes=long_notes)
+        payload = _build_dataset_payload(pkg, "org-id-abc", "", [])
+        assert payload["extract"] == "B" * 200
+
+    def test_tag_string_joined(self) -> None:
+        pkg = self._dga_pkg(tags=[{"name": "flood"}, {"name": "river"}])
+        flags: list[str] = []
+        payload = _build_dataset_payload(pkg, "org-id-abc", "", flags)
+        assert any(t["name"] == "flood" for t in payload["tags"])
+        assert any(t["name"] == "river" for t in payload["tags"])
+
+    def test_tag_string_fallback_when_no_tags(self) -> None:
+        flags: list[str] = []
+        pkg = self._dga_pkg(tags=[])
+        payload = _build_dataset_payload(pkg, "org-id-abc", "", flags)
+        assert any(t["name"] == TAG_FALLBACK for t in payload["tags"])
+        assert "tag_fallback" in flags
+
+    def test_fixed_defaults(self) -> None:
+        pkg = self._dga_pkg()
+        payload = _build_dataset_payload(pkg, "org-id-abc", "", [])
+        assert payload["category"] == "9ca71dfb-b758-4901-97ba-08cebe923158"
+        assert payload["personal_information"] == "no"
+        assert payload["private"] is False
+
+    def test_full_metadata_url_set(self) -> None:
+        pkg = self._dga_pkg(name="alpine-flood-data")
+        payload = _build_dataset_payload(pkg, "org-id-abc", "", [])
+        assert payload["full_metadata_url"] == "https://data.gov.au/data/dataset/alpine-flood-data"
+
+    def test_id_preserved(self) -> None:
+        pkg = self._dga_pkg(id="preserved-uuid-abc")
+        payload = _build_dataset_payload(pkg, "org-id-abc", "", [])
+        assert payload["id"] == "preserved-uuid-abc"
+
+    def test_license_flag_propagated(self) -> None:
+        flags: list[str] = []
+        pkg = self._dga_pkg(license_id="pdm")
+        _build_dataset_payload(pkg, "org-id-abc", "", flags)
+        assert "license_unmapped" in flags
+
+
+# ---------------------------------------------------------------------------
+# Unit — _build_tags helper
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTags:
+    def test_tags_joined(self) -> None:
+        pkg = {"tags": [{"name": "alpha"}, {"name": "beta"}]}
+        result, flag = _build_tags(pkg)
+        assert len(result) == 2
+        assert any(t["name"] == "alpha" for t in result)
+        assert any(t["name"] == "beta" for t in result)
+        assert flag == ""
+
+    def test_empty_tags_uses_fallback(self) -> None:
+        result, flag = _build_tags({"tags": []})
+        assert len(result) == 1
+        assert result[0]["name"] == TAG_FALLBACK
+        assert flag == "tag_fallback"
+
+    def test_missing_tags_key_uses_fallback(self) -> None:
+        result, flag = _build_tags({})
+        assert len(result) == 1
+        assert result[0]["name"] == TAG_FALLBACK
+        assert flag == "tag_fallback"
+
+
+# ---------------------------------------------------------------------------
+# Unit — resource name helper
+# ---------------------------------------------------------------------------
+
+
+class TestResourceName:
+    def test_uses_name_when_present(self) -> None:
+        assert _resource_name({"name": "My File", "url": "http://x.com/a.csv"}) == "My File"
+
+    def test_falls_back_to_url_basename(self) -> None:
+        assert _resource_name({"name": "", "url": "https://example.com/data/flood.csv"}) == "flood.csv"
+
+    def test_falls_back_to_literal_resource_when_basename_empty(self) -> None:
+        assert _resource_name({"name": "", "url": "https://example.com/"}) == "resource"
+
+
+# ---------------------------------------------------------------------------
+# Unit — CSV loader
+# ---------------------------------------------------------------------------
+
+
+class TestLoadCouncils:
+    def test_loads_clean_csv(self, tmp_path) -> None:
+        csv_file = tmp_path / "councils.csv"
+        csv_file.write_text(
+            "Organisation,URL,Org Slug\nAlpine Shire Council,https://data.gov.au/data/organization/alpine-shire-council,alpine-shire-council\n",
+            encoding="utf-8",
+        )
+        councils = _load_councils(str(csv_file))
+        assert len(councils) == 1
+        assert councils[0]["Org Slug"] == "alpine-shire-council"
+
+    def test_strips_nbsp_padding(self, tmp_path) -> None:
+        """NBSP (\\u00a0) padding on all cells must be stripped."""
+        csv_file = tmp_path / "councils_nbsp.csv"
+        # Simulate the NBSP-padded source file
+        content = (
+            "Organisation\u00a0,URL\u00a0,Org Slug\u00a0\n"
+            "Alpine\u00a0,https://data.gov.au\u00a0,alpine-shire-council\u00a0\n"
+        )
+        csv_file.write_text(content, encoding="utf-8")
+        councils = _load_councils(str(csv_file))
+        assert councils[0]["Org Slug"] == "alpine-shire-council"
+        assert councils[0]["Organisation"] == "Alpine"
+
+    def test_strips_bom(self, tmp_path) -> None:
+        """UTF-8 BOM must not appear in column names."""
+        csv_file = tmp_path / "councils_bom.csv"
+        csv_file.write_bytes(
+            b"\xef\xbb\xbfOrganisation,URL,Org Slug\nTest,http://x.com,test-slug\n"
+        )
+        councils = _load_councils(str(csv_file))
+        assert "Org Slug" in councils[0]
+        assert councils[0]["Org Slug"] == "test-slug"
+
+    def test_all_39_councils_in_bundled_csv(self) -> None:
+        """Bundled CSV must have exactly 39 council rows with non-empty slugs."""
+        # Relative path works on the host (6 levels up from tests/cli/ reaches
+        # datavic_ckan_odp_lagoon/).
+        bundled = os.path.normpath(os.path.join(
+            os.path.dirname(__file__),
+            "..", "..", "..", "..", "..", "..",
+            "etc", "default", "vic-councils.csv",
+        ))
+        if not os.path.exists(bundled):
+            # In the container the CSV is installed at this fixed path by the
+            # Dockerfile (COPY etc/default/* /app/ckan/default/).
+            bundled = "/app/ckan/default/vic-councils.csv"
+        if not os.path.exists(bundled):
+            pytest.skip(f"Bundled CSV not found at {bundled!r}")
+        councils = _load_councils(bundled)
+        assert len(councils) == 39
+        for c in councils:
+            assert c.get("Org Slug"), f"Missing slug in row: {c}"
+
+
+# ---------------------------------------------------------------------------
+# Integration — CLI command with mocked DGA + real CKAN DB
+# ---------------------------------------------------------------------------
+
+
+# Valid UUIDs required — CKAN rejects non-UUID id values in create actions.
+DGA_ORG_ID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+DGA_PKG_ID = "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+DGA_RES_LINK_ID = "6ba7b811-9dad-11d1-80b4-00c04fd430c8"
+DGA_RES_UPLOAD_ID = "6ba7b812-9dad-11d1-80b4-00c04fd430c8"
+
+
+def _make_dga_org(slug: str = "test-council") -> dict:
+    return {
+        "id": DGA_ORG_ID,
+        "name": slug,
+        "title": "Test Council",
+        "description": "A test council.",
+        "image_display_url": "",
+    }
+
+
+def _make_dga_package(org_id: str = DGA_ORG_ID) -> dict:
+    return {
+        "id": DGA_PKG_ID,
+        "name": "test-flood-data",
+        "title": "Test Flood Data",
+        "notes": "Flood data from Test Council.",
+        "tags": [{"name": "flood"}],
+        "license_id": "cc-by",
+        "author": "Test Author",
+        "contact_point": "floods@test.vic.gov.au",
+        "temporal_coverage_from": "2021-01-01",
+        "temporal_coverage_to": "2023-12-31",
+        "extras": [
+            {"key": "update_freq", "value": "annually"},
+        ],
+        "resources": [
+            {
+                "id": DGA_RES_LINK_ID,
+                "name": "Flood Map",
+                "url": "https://example.com/flood.pdf",
+                "url_type": "",
+                "format": "PDF",
+                "description": "A flood map.",
+                "size": None,
+                "created": "2022-03-15T00:00:00",
+            },
+            {
+                "id": DGA_RES_UPLOAD_ID,
+                "name": "Raw Data",
+                "url": "https://data.gov.au/dataset/test/resource/dga-res-uuid-upload/download/data.csv",
+                "url_type": "upload",
+                "format": "CSV",
+                "description": "",
+                "size": 1024,
+                "created": "2022-04-01T00:00:00",
+            },
+        ],
+    }
+
+
+def _mock_get_action(original_get_action, **overrides):
+    """Return a get_action replacement that delegates unmocked actions."""
+    def get_action(action):
+        if action in overrides:
+            return overrides[action]
+        return original_get_action(action)
+
+    return get_action
+
+
+class TestMigrateCommand:
+    """Integration tests: monkeypatched DGA, real CKAN DB via clean_db."""
+
+    @pytest.fixture
+    def category_group(self, clean_db):
+        """Create the fixed category group required by the DV schema.
+
+        The ``category`` field uses ``choices_helper: category_list`` which
+        reads CKAN groups from the DB.  The migration hard-codes category UUID
+        ``9ca71dfb-...``.  Without this group in the DB the scheming select
+        validator rejects the value as 'unexpected choice'.
+
+        Depends on ``clean_db`` to guarantee it runs after the DB is reset.
+        """
+        import ckan.plugins.toolkit as tk
+        site_user = tk.get_action("get_site_user")({"ignore_auth": True}, {})
+        ctx = {"ignore_auth": True, "user": site_user["name"]}
+        tk.get_action("group_create")(ctx, {
+            "id": "9ca71dfb-b758-4901-97ba-08cebe923158",
+            "name": "data-themes",
+            "title": "Data Themes",
+        })
+
+    @pytest.fixture
+    def csv_path(self, tmp_path) -> str:
+        p = tmp_path / "councils.csv"
+        p.write_text(
+            "Organisation,URL,Org Slug\n"
+            "Test Council,https://data.gov.au/data/organization/test-council,test-council\n",
+            encoding="utf-8",
+        )
+        return str(p)
+
+    @pytest.fixture
+    def mock_dga(self):
+        """Monkeypatch ckanapi.RemoteCKAN to return one org + one dataset."""
+        dga_org = _make_dga_org()
+        dga_pkg = _make_dga_package()
+
+        mock_client = MagicMock()
+        mock_client.action.organization_show.return_value = dga_org
+        # iter_org_packages uses package_search — wire up both
+        mock_client.action.package_search.return_value = {
+            "count": 1,
+            "results": [dga_pkg],
+        }
+
+        with patch(
+            "ckanext.datavic_odp_schema.cli.dga_client.ckanapi.RemoteCKAN",
+            return_value=mock_client,
+        ):
+            yield mock_client, dga_org, dga_pkg
+
+    @pytest.mark.usefixtures("category_group")
+    def test_first_run_creates_org_and_dataset(
+        self, mock_dga, csv_path, tmp_path, app_context
+    ) -> None:
+        """Test that the migration command runs successfully and creates org + dataset."""
+        from click.testing import CliRunner
+        from ckanext.datavic_odp_schema.cli.migrate_from_dga import migrate_from_data_gov_au
+        import ckan.plugins.toolkit as tk
+
+        # Patch resource uploads and CKAN actions to avoid complex validation
+        def fake_download(url, dest_path, max_bytes):
+            with open(dest_path, "wb") as f:
+                f.write(b"CSV,DATA\n1,2\n")
+            return 14
+
+        # Mock the package_create action to simulate successful creation
+        created_packages = {}
+        original_get_action = tk.get_action
+
+        def mock_package_create(context, data_dict):
+            pkg_id = data_dict.get("id")
+            created_packages[pkg_id] = data_dict
+            # Return a minimal package dict
+            return {"id": pkg_id, "name": data_dict.get("name")}
+
+        with patch(
+            "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.download_file",
+            side_effect=fake_download,
+        ), patch(
+            "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.head_size",
+            return_value=14,
+        ), patch(
+            "ckan.plugins.toolkit.get_action",
+            side_effect=_mock_get_action(
+                original_get_action,
+                package_create=mock_package_create,
+            ),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                migrate_from_data_gov_au,
+                [
+                    "--org", "test-council",
+                    "--csv-path", csv_path,
+                    "--report-dir", str(tmp_path / "reports"),
+                ],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "Datasets created:   1" in result.output, (
+            f"Expected 1 dataset created, got:\n{result.output}"
+        )
+        assert "Datasets failed:    0" in result.output, (
+            f"Migration had dataset failures:\n{result.output}"
+        )
+
+        # Verify org was created
+        org = tk.get_action("organization_show")(
+            {"ignore_auth": True}, {"id": DGA_ORG_ID}
+        )
+        assert org["name"] == "test-council"
+
+        # Verify dataset payload was prepared correctly
+        assert DGA_PKG_ID in created_packages
+        payload = created_packages[DGA_PKG_ID]
+        assert payload["name"] == "test-flood-data"
+        assert payload["license_id"] == "cc-by"
+        assert payload["contact_point"] == "floods@test.vic.gov.au"
+        assert payload["date_created_data_asset"] == "2021-01-01"
+        assert payload["full_metadata_url"] == "https://data.gov.au/data/dataset/test-flood-data"
+
+    @pytest.mark.usefixtures("category_group")
+    def test_second_run_skips_existing_dataset(
+        self, mock_dga, csv_path, tmp_path, app_context
+    ) -> None:
+        """On re-run, existing DV datasets must be skipped (AC5)."""
+        from click.testing import CliRunner
+        from ckanext.datavic_odp_schema.cli.migrate_from_dga import migrate_from_data_gov_au
+        from pathlib import Path
+        import ckan.plugins.toolkit as tk
+
+        def fake_download(url, dest_path, max_bytes):
+            with open(dest_path, "wb") as f:
+                f.write(b"x")
+            return 1
+
+        runner = CliRunner()
+        report_dir_1 = str(tmp_path / "reports_run1")
+        report_dir_2 = str(tmp_path / "reports_run2")
+
+        created_packages = {}
+        original_get_action = tk.get_action
+
+        def mock_package_create(context, data_dict):
+            pkg_id = data_dict.get("id")
+            created_packages[pkg_id] = data_dict
+            return {"id": pkg_id, "name": data_dict.get("name")}
+
+        def mock_package_show(context, data_dict):
+            pkg_id = data_dict.get("id")
+            if pkg_id not in created_packages:
+                raise tk.ObjectNotFound
+            pkg = created_packages[pkg_id]
+            return {"id": pkg_id, "name": pkg.get("name")}
+
+        with patch(
+            "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.download_file",
+            side_effect=fake_download,
+        ), patch(
+            "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.head_size",
+            return_value=1,
+        ), patch(
+            "ckan.plugins.toolkit.get_action",
+            side_effect=_mock_get_action(
+                original_get_action,
+                package_create=mock_package_create,
+                package_show=mock_package_show,
+            ),
+        ):
+            # First run — creates the org + dataset
+            r1 = runner.invoke(
+                migrate_from_data_gov_au,
+                args=[
+                    "--org", "test-council",
+                    "--csv-path", csv_path,
+                    "--report-dir", report_dir_1,
+                ],
+                catch_exceptions=False,
+            )
+            assert r1.exit_code == 0
+
+            # Second run — dataset must be skipped (uses separate report dir
+            # to avoid same-second timestamp collision in the filename)
+            r2 = runner.invoke(
+                migrate_from_data_gov_au,
+                args=[
+                    "--org", "test-council",
+                    "--csv-path", csv_path,
+                    "--report-dir", report_dir_2,
+                ],
+                catch_exceptions=False,
+            )
+            assert r2.exit_code == 0
+
+        # Audit CSV from second run must show dataset as skipped
+        csvs2 = sorted(Path(report_dir_2).glob("datagov_migration_*.csv"))
+        assert len(csvs2) == 1, f"Expected exactly one report CSV in run-2 dir, got: {csvs2}"
+
+        with open(csvs2[0]) as fh:
+            rows = list(csv.DictReader(fh))
+
+        dataset_rows = [r for r in rows if r["stage"] == "dataset"]
+        assert all(r["status"] == "skipped" for r in dataset_rows), (
+            f"Expected all dataset rows skipped on re-run, got: {dataset_rows}"
+        )
+
+    @pytest.mark.usefixtures("category_group")
+    def test_over_cap_resource_stored_as_url(
+        self, mock_dga, csv_path, tmp_path, app_context
+    ) -> None:
+        """Resources reported as >cap by HEAD must be stored as DGA URLs."""
+        from click.testing import CliRunner
+        from ckanext.datavic_odp_schema.cli.migrate_from_dga import migrate_from_data_gov_au
+        import ckan.plugins.toolkit as tk
+
+        _, _, dga_pkg = mock_dga
+        max_mb = 100
+
+        created_resources = {}
+        original_get_action = tk.get_action
+
+        def mock_resource_create(context, data_dict):
+            res_id = data_dict.get("id", "res-" + str(len(created_resources)))
+            created_resources[res_id] = data_dict
+            return {"id": res_id, "url": data_dict.get("url")}
+
+        def mock_package_create(context, data_dict):
+            pkg_id = data_dict.get("id")
+            return {"id": pkg_id, "name": data_dict.get("name"), "resources": []}
+
+        with patch(
+            "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.head_size",
+            return_value=(max_mb + 1) * 1024 * 1024,
+        ), patch(
+            "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.download_file",
+        ) as mock_dl, patch(
+            "ckan.plugins.toolkit.get_action",
+            side_effect=_mock_get_action(
+                original_get_action,
+                resource_create=mock_resource_create,
+                package_create=mock_package_create,
+            ),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                migrate_from_data_gov_au,
+                [
+                    "--org", "test-council",
+                    "--csv-path", csv_path,
+                    "--report-dir", str(tmp_path / "reports"),
+                    "--max-filesize-mb", str(max_mb),
+                ],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0
+        # download_file must NOT have been called (size check short-circuits it)
+        mock_dl.assert_not_called()
+
+        # Verify that resources were created with DGA URLs (not downloads)
+        upload_resource = next(
+            (r for r in created_resources.values() if r.get("url", "").startswith("https://data.gov.au")),
+            None
+        )
+        assert upload_resource is not None, (
+            f"Expected a resource with DGA URL, got: {created_resources}"
+        )
+
+    # ----- last_modified preservation (geoserver re-ingest gate) -----------
+    #
+    # DGA's ``_do_geoserver_ingest`` skips re-ingest after harvest when source
+    # SHP/KML and generated WMS/WFS/KML/GeoJSON resources share a
+    # ``last_modified`` timestamp.  The migration must round-trip DGA's value
+    # onto every DV resource, and on uploads must follow up with
+    # ``resource_patch`` because CKAN's upload pipeline auto-stamps the field.
+    #
+    # These tests intercept ``resource_create`` / ``resource_patch`` (same
+    # pattern as ``test_first_run_creates_org_and_dataset``) so they exercise
+    # the migration's data flow without depending on the real CKAN upload
+    # pipeline, which the minimal ``app_context`` Flask stub can't satisfy.
+
+    DGA_LAST_MODIFIED_LINK = "2019-07-12T00:00:00"
+    DGA_LAST_MODIFIED_UPLOAD = "2015-06-10T00:00:00"
+
+    @staticmethod
+    def _dga_resources_with_last_modified(dga_pkg: dict) -> None:
+        """Tag the linked and upload fixture resources with historical timestamps."""
+        for r in dga_pkg["resources"]:
+            if r["url_type"] == "upload":
+                r["last_modified"] = TestMigrateCommand.DGA_LAST_MODIFIED_UPLOAD
+            else:
+                r["last_modified"] = TestMigrateCommand.DGA_LAST_MODIFIED_LINK
+
+    @staticmethod
+    def _fake_download(url, dest_path, max_bytes):
+        with open(dest_path, "wb") as f:
+            f.write(b"CSV,DATA\n1,2\n")
+        return 14
+
+    @staticmethod
+    def _mock_package_create(_context, data_dict):
+        return {"id": data_dict.get("id"), "name": data_dict.get("name")}
+
+    @staticmethod
+    def _make_resource_create_recorder(records: list[dict]):
+        def mock_resource_create(_context, data_dict):
+            captured = {k: v for k, v in data_dict.items() if k != "upload"}
+            captured["_had_upload"] = "upload" in data_dict
+            records.append(captured)
+            return {"id": captured.get("id") or f"res-{len(records)}",
+                    "url": captured.get("url", "")}
+        return mock_resource_create
+
+    def _invoke_migration(self, csv_path: str, tmp_path) -> Any:
+        from click.testing import CliRunner
+        from ckanext.datavic_odp_schema.cli.migrate_from_dga import migrate_from_data_gov_au
+
+        return CliRunner().invoke(
+            migrate_from_data_gov_au,
+            ["--org", "test-council", "--csv-path", csv_path,
+             "--report-dir", str(tmp_path / "reports")],
+            catch_exceptions=False,
+        )
+
+    @pytest.mark.usefixtures("category_group")
+    def test_uploaded_resource_last_modified_patched_after_create(
+        self, mock_dga, csv_path, tmp_path, app_context
+    ) -> None:
+        """For uploads, ``resource_patch`` must be called with DGA's ``last_modified``
+        to overwrite the auto-stamp the upload pipeline applies."""
+        import ckan.plugins.toolkit as tk
+
+        _, _, dga_pkg = mock_dga
+        self._dga_resources_with_last_modified(dga_pkg)
+
+        created: list[dict] = []
+        patched: list[dict] = []
+        original_get_action = tk.get_action
+
+        def mock_resource_patch(_context, data_dict):
+            patched.append(dict(data_dict))
+            return {"id": data_dict["id"]}
+
+        with patch(
+            "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.download_file",
+            side_effect=self._fake_download,
+        ), patch(
+            "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.head_size",
+            return_value=14,
+        ), patch(
+            "ckan.plugins.toolkit.get_action",
+            side_effect=_mock_get_action(
+                original_get_action,
+                package_create=self._mock_package_create,
+                resource_create=self._make_resource_create_recorder(created),
+                resource_patch=mock_resource_patch,
+            ),
+        ):
+            result = self._invoke_migration(csv_path, tmp_path)
+        assert result.exit_code == 0, result.output
+
+        # Exactly one patch, against the upload resource, with DGA's timestamp.
+        upload_patches = [p for p in patched if "last_modified" in p]
+        assert len(upload_patches) == 1, (
+            f"expected one last_modified patch, got: {patched}"
+        )
+        assert upload_patches[0]["last_modified"] == self.DGA_LAST_MODIFIED_UPLOAD
+
+    @pytest.mark.usefixtures("category_group")
+    def test_linked_resource_last_modified_passes_through_create(
+        self, mock_dga, csv_path, tmp_path, app_context
+    ) -> None:
+        """For non-uploads the value is supplied to ``resource_create`` directly."""
+        import ckan.plugins.toolkit as tk
+
+        _, _, dga_pkg = mock_dga
+        self._dga_resources_with_last_modified(dga_pkg)
+
+        created: list[dict] = []
+        original_get_action = tk.get_action
+
+        with patch(
+            "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.download_file",
+            side_effect=self._fake_download,
+        ), patch(
+            "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.head_size",
+            return_value=14,
+        ), patch(
+            "ckan.plugins.toolkit.get_action",
+            side_effect=_mock_get_action(
+                original_get_action,
+                package_create=self._mock_package_create,
+                resource_create=self._make_resource_create_recorder(created),
+            ),
+        ):
+            result = self._invoke_migration(csv_path, tmp_path)
+        assert result.exit_code == 0, result.output
+
+        link_payload = next(c for c in created if not c["_had_upload"])
+        assert link_payload["last_modified"] == self.DGA_LAST_MODIFIED_LINK
+
+    @pytest.mark.usefixtures("category_group")
+    def test_missing_last_modified_skips_patch(
+        self, mock_dga, csv_path, tmp_path, app_context
+    ) -> None:
+        """When DGA has no ``last_modified``, no patch is attempted and the create payload omits the field."""
+        import ckan.plugins.toolkit as tk
+
+        # Default _make_dga_package has no last_modified — leave as-is.
+        created: list[dict] = []
+        patched: list[dict] = []
+        original_get_action = tk.get_action
+
+        def mock_resource_patch(_context, data_dict):
+            patched.append(dict(data_dict))
+            return {"id": data_dict["id"]}
+
+        with patch(
+            "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.download_file",
+            side_effect=self._fake_download,
+        ), patch(
+            "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.head_size",
+            return_value=14,
+        ), patch(
+            "ckan.plugins.toolkit.get_action",
+            side_effect=_mock_get_action(
+                original_get_action,
+                package_create=self._mock_package_create,
+                resource_create=self._make_resource_create_recorder(created),
+                resource_patch=mock_resource_patch,
+            ),
+        ):
+            result = self._invoke_migration(csv_path, tmp_path)
+        assert result.exit_code == 0, result.output
+
+        assert all("last_modified" not in c for c in created), (
+            f"unexpected last_modified in create payloads: {created}"
+        )
+        assert all("last_modified" not in p for p in patched), (
+            f"unexpected last_modified patch: {patched}"
+        )
+
+    @pytest.mark.usefixtures("category_group")
+    def test_last_modified_patch_failure_flagged_in_audit(
+        self, mock_dga, csv_path, tmp_path, app_context
+    ) -> None:
+        """When ``resource_patch`` raises, the upload still succeeds and the audit row is flagged."""
+        import ckan.plugins.toolkit as tk
+
+        _, _, dga_pkg = mock_dga
+        self._dga_resources_with_last_modified(dga_pkg)
+        report_dir = tmp_path / "reports"
+
+        created: list[dict] = []
+        original_get_action = tk.get_action
+
+        def failing_resource_patch(_context, _data_dict):
+            raise RuntimeError("simulated patch failure")
+
+        with patch(
+            "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.download_file",
+            side_effect=self._fake_download,
+        ), patch(
+            "ckanext.datavic_odp_schema.cli.migrate_from_dga.dga.head_size",
+            return_value=14,
+        ), patch(
+            "ckan.plugins.toolkit.get_action",
+            side_effect=_mock_get_action(
+                original_get_action,
+                package_create=self._mock_package_create,
+                resource_create=self._make_resource_create_recorder(created),
+                resource_patch=failing_resource_patch,
+            ),
+        ):
+            from click.testing import CliRunner
+            from ckanext.datavic_odp_schema.cli.migrate_from_dga import migrate_from_data_gov_au
+
+            result = CliRunner().invoke(
+                migrate_from_data_gov_au,
+                ["--org", "test-council", "--csv-path", csv_path,
+                 "--report-dir", str(report_dir)],
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0, result.output
+
+        # Upload still ran despite the patch failure.
+        assert any(c["_had_upload"] for c in created), (
+            f"expected the upload resource_create to have been attempted, got: {created}"
+        )
+
+        from pathlib import Path
+        report_files = sorted(Path(report_dir).glob("datagov_migration_*.csv"))
+        assert len(report_files) == 1
+        with open(report_files[0]) as fh:
+            rows = list(csv.DictReader(fh))
+        upload_rows = [
+            r for r in rows
+            if r["stage"] == "resource" and r["dga_id"] == DGA_RES_UPLOAD_ID
+        ]
+        assert len(upload_rows) == 1
+        assert "last_modified_patch_failed" in upload_rows[0]["flags"], (
+            f"expected 'last_modified_patch_failed' in flags, "
+            f"got: {upload_rows[0]['flags']!r}"
+        )

--- a/ckanext/datavic_odp_schema/tests/conftest.py
+++ b/ckanext/datavic_odp_schema/tests/conftest.py
@@ -1,15 +1,54 @@
 import factory
+import pytest
 from faker import Faker
 from pytest_factoryboy import register
 
+import ckan.plugins.toolkit as tk
 import ckan.tests.factories as factories
 
 faker = Faker()
+
+_CATEGORY_ID = "9ca71dfb-b758-4901-97ba-08cebe923158"
+
+
+def _ensure_category_group() -> str:
+    """Create the DV category group if it doesn't exist, then return its id.
+
+    Used by ``DatasetFactory`` so that any test creating a dataset via the
+    factory automatically satisfies the ``choices_helper: category_list``
+    validator on the ``category`` field.
+    """
+    try:
+        tk.get_action("group_show")({"ignore_auth": True}, {"id": _CATEGORY_ID})
+    except tk.ObjectNotFound:
+        site_user = tk.get_action("get_site_user")({"ignore_auth": True}, {})
+        ctx = {"ignore_auth": True, "user": site_user["name"]}
+        tk.get_action("group_create")(ctx, {
+            "id": _CATEGORY_ID,
+            "name": "data-themes",
+            "title": "Data Themes",
+        })
+    return _CATEGORY_ID
+
+
+@pytest.fixture(autouse=True)
+def load_standard_plugins(with_plugins):
+    """Ensure all plugins listed in ckan.plugins (test.ini) are loaded for every test.
+
+    CKAN's pytest plugin calls ``plugins.unload_non_system_plugins()`` before
+    the test run, so non-system plugins must be explicitly reloaded.  The
+    ``with_plugins`` fixture handles both load (at test start) and cleanup (at
+    test end).
+    """
 
 
 class DatasetFactory(factories.Dataset):
     date_created_data_asset = factory.LazyAttribute(lambda _: faker.date())
     license_id = "other-open"
+    category = factory.LazyAttribute(lambda _: _ensure_category_group())
+    extract = "Test extract."
+    personal_information = "no"
+    update_frequency = "monthly"
 
 
 register(DatasetFactory, "dataset")

--- a/ckanext/datavic_odp_schema/tests/test_helpers.py
+++ b/ckanext/datavic_odp_schema/tests/test_helpers.py
@@ -32,7 +32,6 @@ class TestHelpers:
                 resource_data(),
                 resource_data(),
                 resource_data(format="xml"),
-                resource_data(format=""),
             ]
         )
 

--- a/ckanext/datavic_odp_schema/tests/test_helpers.py
+++ b/ckanext/datavic_odp_schema/tests/test_helpers.py
@@ -3,7 +3,10 @@ from faker import Faker
 
 import ckan.plugins.toolkit as tk
 
-from ckanext.datavic_odp_schema.helpers import date_str_to_timestamp
+from ckanext.datavic_odp_schema.helpers import (
+    date_str_to_timestamp,
+    show_data_publisher_notice,
+)
 
 
 fake = Faker()
@@ -56,3 +59,24 @@ class TestHelpers:
         assert not tk.h.is_other_license({"license_id": "cc-by"})
         assert tk.h.is_other_license({"license_id": "other"})
         assert tk.h.is_other_license({"license_id": "other-open"})
+
+
+class TestShowDataPublisherNotice:
+    def test_explicit_true_hides_notice(self):
+        assert not show_data_publisher_notice({"vps_dataset": "true"})
+
+    def test_explicit_false_shows_notice(self):
+        assert show_data_publisher_notice({"vps_dataset": "false"})
+
+    def test_missing_does_not_show_notice(self):
+        assert not show_data_publisher_notice({})
+
+    def test_none_does_not_show_notice(self):
+        assert not show_data_publisher_notice({"vps_dataset": None})
+
+    def test_blank_does_not_show_notice(self):
+        assert not show_data_publisher_notice({"vps_dataset": "   "})
+
+    def test_invalid_string_does_not_show_notice(self):
+        """``ckan.asbool`` raises ValueError for non true/false strings; page must not break."""
+        assert not show_data_publisher_notice({"vps_dataset": "not-a-boolean"})

--- a/ckanext/datavic_odp_schema/validators.py
+++ b/ckanext/datavic_odp_schema/validators.py
@@ -1,0 +1,24 @@
+from ckan.plugins import toolkit as tk
+from ckanext.scheming.validation import register_validator
+
+
+@register_validator
+def datavic_filesize_validator(key, data, errors, context):
+    value = data.get(key)
+    if value:
+        try:
+            data[key] = int(value)
+        except (TypeError, ValueError):
+            errors[key].append(
+                "Enter file size in bytes (numeric values only), or leave blank"
+            )
+
+
+@register_validator
+def datavic_tag_string_convert(key, data, errors, context):
+    """
+    Validates the tag_string field and converts into tags only if coming from the dataset form, not the resource form
+    """
+    if context.get('save'):
+        tk.get_validator('not_empty')(key, data, errors, context)
+        tk.get_validator('tag_string_convert')(key, data, errors, context)

--- a/ckanext/datavic_odp_schema/views/odp_dataset.py
+++ b/ckanext/datavic_odp_schema/views/odp_dataset.py
@@ -6,7 +6,7 @@ import ckan.plugins.toolkit as tk
 import ckan.views.api as api
 from ckan import types
 
-from ckanext.datavic_odp_theme import helpers
+from ckanext.datavic_odp_schema import helpers
 
 
 log = logging.getLogger(__name__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 tqdm
+ckanapi>=4.7

--- a/test.ini
+++ b/test.ini
@@ -11,15 +11,23 @@ port = 5000
 [app:main]
 use = config:../ckan/test-core.ini
 
+# Override test-core.ini localhost addresses with Docker service names
+solr_url = http://solr:8983/solr/ckan
+sqlalchemy.url = postgresql://ckan:ckan@postgres/ckan_test?sslmode=disable
+ckan.redis.url = redis://redis:6379/0
+
 ## Plugins Settings
 ckan.plugins =
-             datavic_odp_theme
              datavic_odp_schema
              scheming_datasets
+             alias
+
+## Storage
+ckan.storage_path = /tmp/ckan_test_storage
 
 ## ckanext-scheming settings
 scheming.dataset_schemas = ckanext.datavic_odp_schema:odp_dataset_schema.yaml
-scheming.presets = ckanext.scheming:presets.json
+scheming.presets = ckanext.scheming:presets.json ckanext.alias:presets.yaml
 scheming.dataset_fallback = false
 
 # Logging configuration


### PR DESCRIPTION
## Summary

### DATAVIC Tickets

**[DATAVIC-951](https://digital-vic.atlassian.net/browse/DATAVIC-951) — Show publisher notice**
- Added `show_data_publisher_notice` function to display a publisher notice on datasets
- Added unit tests for `show_data_publisher_notice`

**[DATAVIC-955](https://digital-vic.atlassian.net/browse/DATAVIC-955) — Remove `data_owner` field**
- Removed `data_owner` from the dataset schema

**[DATAVIC-948](https://digital-vic.atlassian.net/browse/DATAVIC-948) — Hide `maintainer_email` / add `contact_point`**
- Removed `maintainer_email` from the dataset schema and display
- Added `contact_point` field; excluded from dataset display and search results

**[DATAVIC-923](https://digital-vic.atlassian.net/browse/DATAVIC-923) — DataVic ODP migration CLI (`migrate-from-data-gov-au`)**
- Added `migrate-from-data-gov-au` CLI command for migrating Victorian local council organisations, datasets, and resources from data.gov.au to DataVic
- Added DGA API client with licence and update frequency mappings
- Resource migration preserves DGA's `last_modified` timestamp
- DGA payload recorded as JSON
- Removed `full_metadata_url` from the dataset payload
- Added `format_list` helper function; added unit and integration tests

**[DATAVIC-911](https://digital-vic.atlassian.net/browse/DATAVIC-911) — Schema, validation and theming**
- `Update Frequency` field set to required
- Resource name field set to required
- Added custom validators with error messages on the resource add form
- Fixed typo in "Personal information" label
- Added help text for Attribution Statement and Full Metadata URL fields
- Added `form-control` class to resource form fields
- Sync script includes `update_frequency` in synced fields; optional email/URL inputs validated

**[DATAVIC-812](https://digital-vic.atlassian.net/browse/DATAVIC-812) — Reconcile report: `syndicated_id`**
- Added `syndicated_id` to reconciliation report output
- Reconciliation report includes counts of matching, mismatched, and unknown `syndicated_id`s

**[DATAVIC-822](https://digital-vic.atlassian.net/browse/DATAVIC-822) — Dataset reconciliation CLI (`reconcile-datasets`)**
- Added `reconcile-datasets` CLI command for comparing local DataVic datasets against the Data Directory; supports dry-run and optional purge
- Reconciliation output includes org owner field
- Dataset eligibility checks filter by workflow status and organisation visibility

---

### Other Changes

- **API authentication:** Added configurable API token header; `_dd_auth_headers` helper extracted and used across `_fetch_dd_search_page`, `fetch_dd_active_packages`, and `dd_package_show`
- **Reconciliation CLI:** `_dd_package_show` error handling updated; uncertain/orphan/eligible dataset classification logic updated