### PR TITLE
[DATAVIC-952] update the data publisher notice and updated tests

### DIFF
--- a/ckanext/datavic_odp_schema/helpers.py
+++ b/ckanext/datavic_odp_schema/helpers.py
@@ -129,21 +129,3 @@ def localized_filesize(size_bytes: int) -> str:
     s = round(float(size_bytes) / p, 1)
 
     return f"{s} {size_name[i]}"
-
-
-def show_data_publisher_notice(pkg_dict: dict[str, Any]) -> bool:
-    """Return True to show the Data publisher notice on the dataset read page.
-
-    If ``vps_dataset`` is missing or blank, return False (no notice). If set to a
-    string CKAN can parse as true/false, show the notice when the value is false
-    for the VPS-lane policy. If the value is not a valid boolean string, return
-    False (no notice) so ``asbool`` does not raise on the read view.
-    """
-    vps_dataset = pkg_dict.get("vps_dataset")
-    if vps_dataset is None or str(vps_dataset).strip() == "":
-        return False
-    try:
-        return not tk.asbool(vps_dataset)
-    except ValueError:
-        return False
-

--- a/ckanext/datavic_odp_schema/odp_dataset_schema.yaml
+++ b/ckanext/datavic_odp_schema/odp_dataset_schema.yaml
@@ -183,11 +183,6 @@ dataset_fields:
   display_snippet: null
   form_snippet: vic_hidden.html
 
-- field_name: vps_dataset
-  display_snippet: null
-  form_snippet: vic_hidden.html
-  validators: default(false) boolean_validator
-
 resource_fields:
 
 - field_name: url

--- a/ckanext/datavic_odp_schema/templates/scheming/package/read.html
+++ b/ckanext/datavic_odp_schema/templates/scheming/package/read.html
@@ -2,8 +2,5 @@
 
 {% block primary_content_inner %}
   {{ super() }}
-
-  {% if h.show_data_publisher_notice(pkg) %}
-    {% snippet "scheming/package/snippets/data_publisher_notice.html", pkg_dict=pkg %}
-  {% endif %}
+  {% snippet "scheming/package/snippets/data_publisher_notice.html", pkg_dict=pkg %}
 {% endblock %}

--- a/ckanext/datavic_odp_schema/templates/scheming/package/snippets/data_publisher_notice.html
+++ b/ckanext/datavic_odp_schema/templates/scheming/package/snippets/data_publisher_notice.html
@@ -1,12 +1,5 @@
-<section class="additional-info">
-  <h3>{{ _('Data source')}}</h3>
-
+<section class="data-publisher-notice">
   <p>
-    {% if pkg_dict.organization %}
-      <a href="{{ h.url_for('organization.read', id=pkg_dict.organization.name) }}">
-        {{ pkg_dict.organization.title or pkg_dict.organization.name }}
-      </a><br/>
-    {% endif %}
     {{ _('Responsibility for legislative and policy compliance rests with the publisher.') }}
   </p>
 </section>

--- a/ckanext/datavic_odp_schema/tests/cli/test_migrate_from_dga.py
+++ b/ckanext/datavic_odp_schema/tests/cli/test_migrate_from_dga.py
@@ -214,11 +214,6 @@ class TestBuildDatasetPayload:
         assert payload["personal_information"] == "no"
         assert payload["private"] is False
 
-    def test_full_metadata_url_set(self) -> None:
-        pkg = self._dga_pkg(name="alpine-flood-data")
-        payload = _build_dataset_payload(pkg, "org-id-abc", "", [])
-        assert payload["full_metadata_url"] == "https://data.gov.au/data/dataset/alpine-flood-data"
-
     def test_id_preserved(self) -> None:
         pkg = self._dga_pkg(id="preserved-uuid-abc")
         payload = _build_dataset_payload(pkg, "org-id-abc", "", [])
@@ -529,7 +524,6 @@ class TestMigrateCommand:
         assert payload["license_id"] == "cc-by"
         assert payload["contact_point"] == "floods@test.vic.gov.au"
         assert payload["date_created_data_asset"] == "2021-01-01"
-        assert payload["full_metadata_url"] == "https://data.gov.au/data/dataset/test-flood-data"
 
     @pytest.mark.usefixtures("category_group")
     def test_second_run_skips_existing_dataset(

--- a/ckanext/datavic_odp_schema/tests/test_helpers.py
+++ b/ckanext/datavic_odp_schema/tests/test_helpers.py
@@ -4,8 +4,7 @@ from faker import Faker
 import ckan.plugins.toolkit as tk
 
 from ckanext.datavic_odp_schema.helpers import (
-    date_str_to_timestamp,
-    show_data_publisher_notice,
+    date_str_to_timestamp
 )
 
 
@@ -51,7 +50,7 @@ class TestHelpers:
         assert date_str_to_timestamp("2023-02-07T13:19:10.373545")
         assert not date_str_to_timestamp("")
         assert not date_str_to_timestamp(None)
-        assert not date_str_to_timestamp((1,1))
+        assert not date_str_to_timestamp((1, 1))
 
     def test_is_other_license(self):
         assert not tk.h.is_other_license({})
@@ -59,24 +58,3 @@ class TestHelpers:
         assert not tk.h.is_other_license({"license_id": "cc-by"})
         assert tk.h.is_other_license({"license_id": "other"})
         assert tk.h.is_other_license({"license_id": "other-open"})
-
-
-class TestShowDataPublisherNotice:
-    def test_explicit_true_hides_notice(self):
-        assert not show_data_publisher_notice({"vps_dataset": "true"})
-
-    def test_explicit_false_shows_notice(self):
-        assert show_data_publisher_notice({"vps_dataset": "false"})
-
-    def test_missing_does_not_show_notice(self):
-        assert not show_data_publisher_notice({})
-
-    def test_none_does_not_show_notice(self):
-        assert not show_data_publisher_notice({"vps_dataset": None})
-
-    def test_blank_does_not_show_notice(self):
-        assert not show_data_publisher_notice({"vps_dataset": "   "})
-
-    def test_invalid_string_does_not_show_notice(self):
-        """``ckan.asbool`` raises ValueError for non true/false strings; page must not break."""
-        assert not show_data_publisher_notice({"vps_dataset": "not-a-boolean"})


### PR DESCRIPTION
https://digital-vic.atlassian.net/browse/DATAVIC-952

Changes
- removed `vps_dataset` field
- removed helpers
- removed related tests
- update broken test due to removal of `full_metadata_url` from the migration.