### PR TITLE
Hotfix DATAVIC-983: Syndicated upload files not syching

### DIFF
--- a/ckanext/datavic_odp_schema/plugin.py
+++ b/ckanext/datavic_odp_schema/plugin.py
@@ -8,6 +8,27 @@ from ckanext.datavic_odp_schema import validators
 log = logging.getLogger(__name__)
 
 
+def _session_context():
+    """Fallback for hooks that receive no context (e.g. after_dataset_search)."""
+    try:
+        session = tk.ckan.model.Session()
+        return getattr(session, "_context", None) or {}
+    except Exception:
+        return {}
+
+
+def _is_api_request(context=None):
+    """True for public API reads; false for internal write-time reads (for_update) or non-API calls."""
+    ctx = context if context is not None else _session_context()
+    return bool(ctx.get("api_version")) and not ctx.get("for_update")
+
+
+def _strip_custodian_fields(pkg_dict):
+    """Remove sensitive custodian fields before returning a package dict to the public API."""
+    pkg_dict.pop("maintainer_email", None)
+    pkg_dict.pop("data_owner", None)
+
+
 @tk.blanket.blueprints
 @tk.blanket.cli
 @tk.blanket.helpers
@@ -22,12 +43,12 @@ class DatavicODPSchema(p.SingletonPlugin):
 
     # IPackageController
     def after_dataset_show(self, context, pkg_dict):
-        pkg_dict.pop("maintainer_email", None)
-        pkg_dict.pop("data_owner", None)
+        if _is_api_request(context):
+            _strip_custodian_fields(pkg_dict)
         return pkg_dict
 
     def after_dataset_search(self, search_results, search_params):
-        for item in search_results.get("results", []):
-            item.pop("maintainer_email", None)
-            item.pop("data_owner", None)
+        if _is_api_request():
+            for item in search_results.get("results", []):
+                _strip_custodian_fields(item)
         return search_results

--- a/ckanext/datavic_odp_schema/tests/test_custodian_fields.py
+++ b/ckanext/datavic_odp_schema/tests/test_custodian_fields.py
@@ -1,0 +1,145 @@
+import pytest
+
+import ckan.model as model
+import ckan.plugins.toolkit as tk
+
+CUSTODIAN_FIELDS = ("maintainer_email", "data_owner")
+
+_DATA_OWNER = "Data Custodian Team"
+_MAINTAINER_EMAIL = "custodian@example.vic.gov.au"
+
+
+def _sysadmin_context():
+    user = tk.get_action("get_site_user")({"ignore_auth": True}, {})
+    return {"user": user["name"], "ignore_auth": True}
+
+
+def _api_context():
+    ctx = _sysadmin_context()
+    ctx["api_version"] = 3
+    return ctx
+
+
+@pytest.fixture
+def custodian_dataset(dataset_factory):
+    return dataset_factory(
+        contact_point="contact@example.vic.gov.au",
+        data_owner=_DATA_OWNER,
+        maintainer_email=_MAINTAINER_EMAIL,
+    )
+
+
+@pytest.mark.usefixtures("clean_db", "clean_index")
+class TestCustodianFieldStripping:
+    def test_package_show_strips_on_api_request(self, custodian_dataset):
+        result = tk.get_action("package_show")(
+            _api_context(), {"id": custodian_dataset["id"]}
+        )
+        for field in CUSTODIAN_FIELDS:
+            assert field not in result
+
+    def test_package_show_keeps_fields_for_internal_call(self, custodian_dataset):
+        result = tk.get_action("package_show")(
+            _sysadmin_context(), {"id": custodian_dataset["id"]}
+        )
+        assert result["data_owner"] == _DATA_OWNER
+        assert result["maintainer_email"] == _MAINTAINER_EMAIL
+
+    def test_package_patch_preserves_custodian_fields(self, custodian_dataset):
+        tk.get_action("package_patch")(
+            _api_context(),
+            {"id": custodian_dataset["id"], "notes": "patched via api"},
+        )
+
+        result = tk.get_action("package_show")(
+            _sysadmin_context(), {"id": custodian_dataset["id"]}
+        )
+        assert result["notes"] == "patched via api"
+        assert result["data_owner"] == _DATA_OWNER
+        assert result["maintainer_email"] == _MAINTAINER_EMAIL
+
+    def test_package_update_preserves_custodian_fields(self, custodian_dataset):
+        pkg = tk.get_action("package_show")(
+            _sysadmin_context(), {"id": custodian_dataset["id"]}
+        )
+        pkg["notes"] = "updated via api"
+
+        tk.get_action("package_update")(_api_context(), pkg)
+
+        result = tk.get_action("package_show")(
+            _sysadmin_context(), {"id": custodian_dataset["id"]}
+        )
+        assert result["notes"] == "updated via api"
+        assert result["data_owner"] == _DATA_OWNER
+        assert result["maintainer_email"] == _MAINTAINER_EMAIL
+
+    def test_resource_patch_preserves_custodian_fields(self, custodian_dataset):
+        resource = tk.get_action("resource_create")(
+            _sysadmin_context(),
+            {
+                "package_id": custodian_dataset["id"],
+                "url": "http://example.com/data.csv",
+                "name": "Test resource",
+            },
+        )
+
+        tk.get_action("resource_patch")(
+            _api_context(),
+            {"id": resource["id"], "name": "Renamed resource"},
+        )
+
+        result = tk.get_action("package_show")(
+            _sysadmin_context(), {"id": custodian_dataset["id"]}
+        )
+        assert result["resources"][0]["name"] == "Renamed resource"
+        assert result["data_owner"] == _DATA_OWNER
+        assert result["maintainer_email"] == _MAINTAINER_EMAIL
+
+    def test_resource_update_preserves_custodian_fields(self, custodian_dataset):
+        resource = tk.get_action("resource_create")(
+            _sysadmin_context(),
+            {
+                "package_id": custodian_dataset["id"],
+                "url": "http://example.com/data.csv",
+                "name": "Test resource",
+            },
+        )
+
+        resource["name"] = "Updated resource"
+        tk.get_action("resource_update")(_api_context(), resource)
+
+        result = tk.get_action("package_show")(
+            _sysadmin_context(), {"id": custodian_dataset["id"]}
+        )
+        assert result["resources"][0]["name"] == "Updated resource"
+        assert result["data_owner"] == _DATA_OWNER
+        assert result["maintainer_email"] == _MAINTAINER_EMAIL
+
+    def test_package_search_strips_on_api_request(self, custodian_dataset):
+        session = model.Session()
+        session._context = {"api_version": 3}
+        try:
+            result = tk.get_action("package_search")(
+                _sysadmin_context(), {"q": custodian_dataset["name"]}
+            )
+        finally:
+            session._context = None
+
+        assert result["count"] >= 1
+        for pkg in result["results"]:
+            for field in CUSTODIAN_FIELDS:
+                assert field not in pkg
+
+    def test_package_search_keeps_fields_for_internal_call(self, custodian_dataset):
+        session = model.Session()
+        session._context = None
+        result = tk.get_action("package_search")(
+            _sysadmin_context(), {"q": custodian_dataset["name"]}
+        )
+
+        assert result["count"] >= 1
+        match = next(
+            pkg for pkg in result["results"] if pkg["id"] == custodian_dataset["id"]
+        )
+        assert match["data_owner"] == _DATA_OWNER
+        assert match["maintainer_email"] == _MAINTAINER_EMAIL


### PR DESCRIPTION
## Problem
`maintainer_email` and `data_owner` were being silently cleared whenever a
dataset or resource was updated via the API. CKAN internally fetches the current
record before applying an update, and the custodian field stripping was firing
on that internal fetch, wiping both fields before they were saved.
## Fix
`after_dataset_show` now uses the per-call action context instead of the
session-global to determine if a request is a public API read. CKAN sets
`for_update=True` on internal write-time fetches, so the updated condition is:
    api_version present AND for_update not set
Public `package_show` and `package_search` responses continue to strip the
fields. Internal fetches during patch/update operations are left untouched.
`_is_api_request()` updated to accept an optional context, unifying the logic
for both `after_dataset_show` and `after_dataset_search`.
## Tests
8 regression tests added in `tests/test_custodian_fields.py` covering:
- package_show / package_search strip on public API, keep on internal calls
- package_patch, resource_patch, package_update, resource_update all preserve
  both fields