### PR TITLE
Release: 2.10.9 – Syndicated upload files not syching

### DIFF
--- a/ckanext/datavic_odp_schema/cli/sync_from_dd.py
+++ b/ckanext/datavic_odp_schema/cli/sync_from_dd.py
@@ -41,6 +41,7 @@ EXTRA_SYNC_FIELDS: list[str] = [
     "category",
     "personal_information",
     "data_owner",
+    "contact_point",
     "custom_licence_link",
     "update_frequency",
 ]
@@ -188,7 +189,7 @@ def sync_syndicated_fields(dry_run: bool, report_path: str | None) -> None:
 
         ckan -c $CKAN_INI search-index rebuild
 
-    Fields synced: category, personal_information, data_owner,
+    Fields synced: category, personal_information, data_owner, contact_point
     custom_licence_link, update_frequency, maintainer_email.
     """
     mode = "DRY-RUN" if dry_run else "SYNC"

--- a/ckanext/datavic_odp_schema/helpers.py
+++ b/ckanext/datavic_odp_schema/helpers.py
@@ -129,3 +129,14 @@ def localized_filesize(size_bytes: int) -> str:
     s = round(float(size_bytes) / p, 1)
 
     return f"{s} {size_name[i]}"
+
+
+def is_email(value) -> bool:
+    if not value:
+        return False
+
+    try:
+        tk.get_validator("email_validator")(value, {})
+        return True
+    except tk.Invalid:
+        return False

--- a/ckanext/datavic_odp_schema/logic/validators.py
+++ b/ckanext/datavic_odp_schema/logic/validators.py
@@ -2,10 +2,6 @@
 
 import ckan.plugins.toolkit as tk
 
-from urllib.parse import urlparse
-from ckan.logic.validators import email_validator as ckan_email_validator
-from ckan.lib.navl.dictization_functions import Invalid
-
 
 def required_if_license_other(key, data, errors, context):
     """
@@ -36,17 +32,13 @@ def url_email_validator(key, data, errors, context):
 
     # Try to validate as email
     try:
-        ckan_email_validator(value, context)
+        tk.get_validator("email_validator")(value, context)
         return
-    except Invalid:
+    except tk.Invalid:
         pass
 
     # Try to validate as URL
-    try:
-        parsed = urlparse(value)
-        if parsed.scheme and parsed.netloc and parsed.scheme in ("http", "https"):
-            return
-    except (ValueError, TypeError):
-        pass
+    if tk.h.is_url(value):
+        return
 
     errors[key].append(tk._("Must be a valid email address or URL"))

--- a/ckanext/datavic_odp_schema/odp_dataset_schema.yaml
+++ b/ckanext/datavic_odp_schema/odp_dataset_schema.yaml
@@ -166,14 +166,16 @@ dataset_fields:
   display_group: Custodian
   form_snippet: text.html
   help_text: The team or individual responsible for managing this dataset.
+  required: true
 
 - field_name: contact_point
   label: Point of contact
-  form_placeholder: email
-  validators: ignore_missing url_email_validator
+  form_placeholder: Valid email or URL
+  validators: url_email_validator
   display_group: Custodian
   form_snippet: text.html
   help_text: Shared inbox or contact form for user queries e.g. https://data.melbourne.vic.gov.au/pages/contact_us_form/
+  required: true
 
 - field_name: nominated_view_id
   display_snippet: null

--- a/ckanext/datavic_odp_schema/plugin.py
+++ b/ckanext/datavic_odp_schema/plugin.py
@@ -8,6 +8,27 @@ from ckanext.datavic_odp_schema import validators
 log = logging.getLogger(__name__)
 
 
+def _session_context():
+    """Fallback for hooks that receive no context (e.g. after_dataset_search)."""
+    try:
+        session = tk.ckan.model.Session()
+        return getattr(session, "_context", None) or {}
+    except Exception:
+        return {}
+
+
+def _is_api_request(context=None):
+    """True for public API reads; false for internal write-time reads (for_update) or non-API calls."""
+    ctx = context if context is not None else _session_context()
+    return bool(ctx.get("api_version")) and not ctx.get("for_update")
+
+
+def _strip_custodian_fields(pkg_dict):
+    """Remove sensitive custodian fields before returning a package dict to the public API."""
+    pkg_dict.pop("maintainer_email", None)
+    pkg_dict.pop("data_owner", None)
+
+
 @tk.blanket.blueprints
 @tk.blanket.cli
 @tk.blanket.helpers
@@ -22,12 +43,12 @@ class DatavicODPSchema(p.SingletonPlugin):
 
     # IPackageController
     def after_dataset_show(self, context, pkg_dict):
-        pkg_dict.pop("maintainer_email", None)
-        pkg_dict.pop("data_owner", None)
+        if _is_api_request(context):
+            _strip_custodian_fields(pkg_dict)
         return pkg_dict
 
     def after_dataset_search(self, search_results, search_params):
-        for item in search_results.get("results", []):
-            item.pop("maintainer_email", None)
-            item.pop("data_owner", None)
+        if _is_api_request():
+            for item in search_results.get("results", []):
+                _strip_custodian_fields(item)
         return search_results

--- a/ckanext/datavic_odp_schema/plugin.py
+++ b/ckanext/datavic_odp_schema/plugin.py
@@ -8,6 +8,24 @@ from ckanext.datavic_odp_schema import validators
 log = logging.getLogger(__name__)
 
 
+def _action_context():
+    """Return the CKAN action context stored on the current SQLAlchemy session."""
+    try:
+        session = tk.ckan.model.Session()
+        return getattr(session, "_context", None) or {}
+    except Exception:
+        return {}
+
+
+def _is_api_request():
+    return bool(_action_context().get("api_version"))
+
+
+def _strip_custodian_fields(pkg_dict):
+    pkg_dict.pop("maintainer_email", None)
+    pkg_dict.pop("data_owner", None)
+
+
 @tk.blanket.blueprints
 @tk.blanket.cli
 @tk.blanket.helpers
@@ -22,12 +40,12 @@ class DatavicODPSchema(p.SingletonPlugin):
 
     # IPackageController
     def after_dataset_show(self, context, pkg_dict):
-        pkg_dict.pop("maintainer_email", None)
-        pkg_dict.pop("data_owner", None)
+        if _is_api_request():
+            _strip_custodian_fields(pkg_dict)
         return pkg_dict
 
     def after_dataset_search(self, search_results, search_params):
-        for item in search_results.get("results", []):
-            item.pop("maintainer_email", None)
-            item.pop("data_owner", None)
+        if _is_api_request():
+            for item in search_results.get("results", []):
+                _strip_custodian_fields(item)
         return search_results

--- a/ckanext/datavic_odp_schema/templates/scheming/package/snippets/additional_info.html
+++ b/ckanext/datavic_odp_schema/templates/scheming/package/snippets/additional_info.html
@@ -116,7 +116,15 @@
         {% if pkg_dict.contact_point %}
           <tr>
             <th scope="row" class="dataset-label">{{ _("Point of contact") }}</th>
-            <td class="dataset-details">{{ pkg_dict.contact_point }}</td>
+            <td class="dataset-details">
+              {% if h.is_url(pkg_dict.contact_point) %}
+                <a href="{{ pkg_dict.contact_point }}" target="_blank" rel="nofollow">{{ pkg_dict.contact_point }}</a>
+              {% elif h.is_email(pkg_dict.contact_point) %}
+                <a href="mailto:{{ pkg_dict.contact_point }}">{{ pkg_dict.contact_point }}</a>
+              {% else %}
+                {{ pkg_dict.contact_point }}
+              {% endif %}
+            </td>
           </tr>
         {% endif %}
       {% endblock %}

--- a/ckanext/datavic_odp_schema/tests/test_custodian_fields.py
+++ b/ckanext/datavic_odp_schema/tests/test_custodian_fields.py
@@ -1,0 +1,145 @@
+import pytest
+
+import ckan.model as model
+import ckan.plugins.toolkit as tk
+
+CUSTODIAN_FIELDS = ("maintainer_email", "data_owner")
+
+_DATA_OWNER = "Data Custodian Team"
+_MAINTAINER_EMAIL = "custodian@example.vic.gov.au"
+
+
+def _sysadmin_context():
+    user = tk.get_action("get_site_user")({"ignore_auth": True}, {})
+    return {"user": user["name"], "ignore_auth": True}
+
+
+def _api_context():
+    ctx = _sysadmin_context()
+    ctx["api_version"] = 3
+    return ctx
+
+
+@pytest.fixture
+def custodian_dataset(dataset_factory):
+    return dataset_factory(
+        contact_point="contact@example.vic.gov.au",
+        data_owner=_DATA_OWNER,
+        maintainer_email=_MAINTAINER_EMAIL,
+    )
+
+
+@pytest.mark.usefixtures("clean_db", "clean_index")
+class TestCustodianFieldStripping:
+    def test_package_show_strips_on_api_request(self, custodian_dataset):
+        result = tk.get_action("package_show")(
+            _api_context(), {"id": custodian_dataset["id"]}
+        )
+        for field in CUSTODIAN_FIELDS:
+            assert field not in result
+
+    def test_package_show_keeps_fields_for_internal_call(self, custodian_dataset):
+        result = tk.get_action("package_show")(
+            _sysadmin_context(), {"id": custodian_dataset["id"]}
+        )
+        assert result["data_owner"] == _DATA_OWNER
+        assert result["maintainer_email"] == _MAINTAINER_EMAIL
+
+    def test_package_patch_preserves_custodian_fields(self, custodian_dataset):
+        tk.get_action("package_patch")(
+            _api_context(),
+            {"id": custodian_dataset["id"], "notes": "patched via api"},
+        )
+
+        result = tk.get_action("package_show")(
+            _sysadmin_context(), {"id": custodian_dataset["id"]}
+        )
+        assert result["notes"] == "patched via api"
+        assert result["data_owner"] == _DATA_OWNER
+        assert result["maintainer_email"] == _MAINTAINER_EMAIL
+
+    def test_package_update_preserves_custodian_fields(self, custodian_dataset):
+        pkg = tk.get_action("package_show")(
+            _sysadmin_context(), {"id": custodian_dataset["id"]}
+        )
+        pkg["notes"] = "updated via api"
+
+        tk.get_action("package_update")(_api_context(), pkg)
+
+        result = tk.get_action("package_show")(
+            _sysadmin_context(), {"id": custodian_dataset["id"]}
+        )
+        assert result["notes"] == "updated via api"
+        assert result["data_owner"] == _DATA_OWNER
+        assert result["maintainer_email"] == _MAINTAINER_EMAIL
+
+    def test_resource_patch_preserves_custodian_fields(self, custodian_dataset):
+        resource = tk.get_action("resource_create")(
+            _sysadmin_context(),
+            {
+                "package_id": custodian_dataset["id"],
+                "url": "http://example.com/data.csv",
+                "name": "Test resource",
+            },
+        )
+
+        tk.get_action("resource_patch")(
+            _api_context(),
+            {"id": resource["id"], "name": "Renamed resource"},
+        )
+
+        result = tk.get_action("package_show")(
+            _sysadmin_context(), {"id": custodian_dataset["id"]}
+        )
+        assert result["resources"][0]["name"] == "Renamed resource"
+        assert result["data_owner"] == _DATA_OWNER
+        assert result["maintainer_email"] == _MAINTAINER_EMAIL
+
+    def test_resource_update_preserves_custodian_fields(self, custodian_dataset):
+        resource = tk.get_action("resource_create")(
+            _sysadmin_context(),
+            {
+                "package_id": custodian_dataset["id"],
+                "url": "http://example.com/data.csv",
+                "name": "Test resource",
+            },
+        )
+
+        resource["name"] = "Updated resource"
+        tk.get_action("resource_update")(_api_context(), resource)
+
+        result = tk.get_action("package_show")(
+            _sysadmin_context(), {"id": custodian_dataset["id"]}
+        )
+        assert result["resources"][0]["name"] == "Updated resource"
+        assert result["data_owner"] == _DATA_OWNER
+        assert result["maintainer_email"] == _MAINTAINER_EMAIL
+
+    def test_package_search_strips_on_api_request(self, custodian_dataset):
+        session = model.Session()
+        session._context = {"api_version": 3}
+        try:
+            result = tk.get_action("package_search")(
+                _sysadmin_context(), {"q": custodian_dataset["name"]}
+            )
+        finally:
+            session._context = None
+
+        assert result["count"] >= 1
+        for pkg in result["results"]:
+            for field in CUSTODIAN_FIELDS:
+                assert field not in pkg
+
+    def test_package_search_keeps_fields_for_internal_call(self, custodian_dataset):
+        session = model.Session()
+        session._context = None
+        result = tk.get_action("package_search")(
+            _sysadmin_context(), {"q": custodian_dataset["name"]}
+        )
+
+        assert result["count"] >= 1
+        match = next(
+            pkg for pkg in result["results"] if pkg["id"] == custodian_dataset["id"]
+        )
+        assert match["data_owner"] == _DATA_OWNER
+        assert match["maintainer_email"] == _MAINTAINER_EMAIL


### PR DESCRIPTION
## Summary

### DATAVIC Tickets

**[DATAVIC-983](https://digital-vic.atlassian.net/browse/DATAVIC-983) — Syndicated upload files not syching**
- `plugin.py`: `_is_api_request()` returns true only when `api_version` is set and `for_update` is not; custodian fields stripped on public API reads only
- `plugin.py`: adds `_session_context()`, `_strip_custodian_fields()` helpers used by `after_dataset_show` and `after_dataset_search`
- `tests/test_custodian_fields.py`: 8 regression tests for `package_show`, `package_search`, `package_patch`, `package_update`, `resource_patch`, and `resource_update`

[DATAVIC-983]: https://digital-vic.atlassian.net/browse/DATAVIC-983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ