### PR TITLE
Release: 2.10.10 – point of contact & login eligibility

### DIFF
--- a/ckanext/datavic_odp_schema/cli/sync_from_dd.py
+++ b/ckanext/datavic_odp_schema/cli/sync_from_dd.py
@@ -41,6 +41,7 @@ EXTRA_SYNC_FIELDS: list[str] = [
     "category",
     "personal_information",
     "data_owner",
+    "contact_point",
     "custom_licence_link",
     "update_frequency",
 ]
@@ -188,7 +189,7 @@ def sync_syndicated_fields(dry_run: bool, report_path: str | None) -> None:
 
         ckan -c $CKAN_INI search-index rebuild
 
-    Fields synced: category, personal_information, data_owner,
+    Fields synced: category, personal_information, data_owner, contact_point
     custom_licence_link, update_frequency, maintainer_email.
     """
     mode = "DRY-RUN" if dry_run else "SYNC"

--- a/ckanext/datavic_odp_schema/helpers.py
+++ b/ckanext/datavic_odp_schema/helpers.py
@@ -129,3 +129,14 @@ def localized_filesize(size_bytes: int) -> str:
     s = round(float(size_bytes) / p, 1)
 
     return f"{s} {size_name[i]}"
+
+
+def is_email(value) -> bool:
+    if not value:
+        return False
+
+    try:
+        tk.get_validator("email_validator")(value, {})
+        return True
+    except tk.Invalid:
+        return False

--- a/ckanext/datavic_odp_schema/logic/validators.py
+++ b/ckanext/datavic_odp_schema/logic/validators.py
@@ -2,10 +2,6 @@
 
 import ckan.plugins.toolkit as tk
 
-from urllib.parse import urlparse
-from ckan.logic.validators import email_validator as ckan_email_validator
-from ckan.lib.navl.dictization_functions import Invalid
-
 
 def required_if_license_other(key, data, errors, context):
     """
@@ -36,17 +32,13 @@ def url_email_validator(key, data, errors, context):
 
     # Try to validate as email
     try:
-        ckan_email_validator(value, context)
+        tk.get_validator("email_validator")(value, context)
         return
-    except Invalid:
+    except tk.Invalid:
         pass
 
     # Try to validate as URL
-    try:
-        parsed = urlparse(value)
-        if parsed.scheme and parsed.netloc and parsed.scheme in ("http", "https"):
-            return
-    except (ValueError, TypeError):
-        pass
+    if tk.h.is_url(value):
+        return
 
     errors[key].append(tk._("Must be a valid email address or URL"))

--- a/ckanext/datavic_odp_schema/odp_dataset_schema.yaml
+++ b/ckanext/datavic_odp_schema/odp_dataset_schema.yaml
@@ -171,7 +171,7 @@ dataset_fields:
 - field_name: contact_point
   label: Point of contact
   form_placeholder: Valid email or URL
-  validators: url_email_validator
+  validators: not_empty url_email_validator
   display_group: Custodian
   form_snippet: text.html
   help_text: Shared inbox or contact form for user queries e.g. https://data.melbourne.vic.gov.au/pages/contact_us_form/

--- a/ckanext/datavic_odp_schema/odp_dataset_schema.yaml
+++ b/ckanext/datavic_odp_schema/odp_dataset_schema.yaml
@@ -166,14 +166,16 @@ dataset_fields:
   display_group: Custodian
   form_snippet: text.html
   help_text: The team or individual responsible for managing this dataset.
+  required: true
 
 - field_name: contact_point
   label: Point of contact
-  form_placeholder: email
-  validators: ignore_missing url_email_validator
+  form_placeholder: Valid email or URL
+  validators: url_email_validator
   display_group: Custodian
   form_snippet: text.html
   help_text: Shared inbox or contact form for user queries e.g. https://data.melbourne.vic.gov.au/pages/contact_us_form/
+  required: true
 
 - field_name: nominated_view_id
   display_snippet: null

--- a/ckanext/datavic_odp_schema/plugin.py
+++ b/ckanext/datavic_odp_schema/plugin.py
@@ -8,6 +8,24 @@ from ckanext.datavic_odp_schema import validators
 log = logging.getLogger(__name__)
 
 
+def _action_context():
+    """Return the CKAN action context stored on the current SQLAlchemy session."""
+    try:
+        session = tk.ckan.model.Session()
+        return getattr(session, "_context", None) or {}
+    except Exception:
+        return {}
+
+
+def _is_api_request():
+    return bool(_action_context().get("api_version"))
+
+
+def _strip_custodian_fields(pkg_dict):
+    pkg_dict.pop("maintainer_email", None)
+    pkg_dict.pop("data_owner", None)
+
+
 @tk.blanket.blueprints
 @tk.blanket.cli
 @tk.blanket.helpers
@@ -22,12 +40,12 @@ class DatavicODPSchema(p.SingletonPlugin):
 
     # IPackageController
     def after_dataset_show(self, context, pkg_dict):
-        pkg_dict.pop("maintainer_email", None)
-        pkg_dict.pop("data_owner", None)
+        if _is_api_request():
+            _strip_custodian_fields(pkg_dict)
         return pkg_dict
 
     def after_dataset_search(self, search_results, search_params):
-        for item in search_results.get("results", []):
-            item.pop("maintainer_email", None)
-            item.pop("data_owner", None)
+        if _is_api_request():
+            for item in search_results.get("results", []):
+                _strip_custodian_fields(item)
         return search_results

--- a/ckanext/datavic_odp_schema/templates/scheming/package/snippets/additional_info.html
+++ b/ckanext/datavic_odp_schema/templates/scheming/package/snippets/additional_info.html
@@ -116,7 +116,15 @@
         {% if pkg_dict.contact_point %}
           <tr>
             <th scope="row" class="dataset-label">{{ _("Point of contact") }}</th>
-            <td class="dataset-details">{{ pkg_dict.contact_point }}</td>
+            <td class="dataset-details">
+              {% if h.is_url(pkg_dict.contact_point) %}
+                <a href="{{ pkg_dict.contact_point }}" target="_blank" rel="nofollow">{{ pkg_dict.contact_point }}</a>
+              {% elif h.is_email(pkg_dict.contact_point) %}
+                <a href="mailto:{{ pkg_dict.contact_point }}">{{ pkg_dict.contact_point }}</a>
+              {% else %}
+                {{ pkg_dict.contact_point }}
+              {% endif %}
+            </td>
           </tr>
         {% endif %}
       {% endblock %}


### PR DESCRIPTION
## Summary

### DATAVIC Tickets

**[DATAVIC-949](https://digital-vic.atlassian.net/browse/DATAVIC-949) — DV/DD metadata schema changes - point of contact & data owner**
- `odp_dataset_schema.yaml`: `data_owner` and `contact_point` marked `required: true`; `contact_point` validators changed to `not_empty url_email_validator`; placeholder updated to “Valid email or URL”
- `url_email_validator`: uses `email_validator` toolkit validator and `h.is_url` instead of direct `urlparse` / CKAN email validator imports
- `helpers.is_email`: new helper wrapping `email_validator`
- `additional_info.html`: Point of contact renders as `mailto:` or external link when value is email or URL
- `sync_from_dd.py`: adds `contact_point` to the syndicated fields list

[DATAVIC-949]: https://digital-vic.atlassian.net/browse/DATAVIC-949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ