### PR TITLE
[DATAVIC-990] Exempt sysadmins from data_owner stripping on public API

### DIFF
--- a/ckanext/datavic_odp_schema/plugin.py
+++ b/ckanext/datavic_odp_schema/plugin.py
@@ -1,5 +1,6 @@
 import logging
 
+import ckan.authz as authz
 import ckan.plugins as p
 import ckan.plugins.toolkit as tk
 
@@ -23,10 +24,30 @@ def _is_api_request(context=None):
     return bool(ctx.get("api_version")) and not ctx.get("for_update")
 
 
-def _strip_custodian_fields(pkg_dict):
-    """Remove sensitive custodian fields before returning a package dict to the public API."""
+def _is_sysadmin(context=None):
+    """Return True if the requesting user is a sysadmin, False otherwise (fail-closed)."""
+    ctx = context if context is not None else _session_context()
+    user = ctx.get("user")
+    if not user:
+        return False
+    try:
+        return authz.is_sysadmin(user)
+    except Exception:
+        log.warning(
+            "Could not determine sysadmin status for custodian stripping",
+            exc_info=True,
+        )
+        return False
+
+
+def _strip_custodian_fields(pkg_dict, is_sysadmin=False):
+    """Strip custodian fields from a package dict for public API responses.
+
+    maintainer_email is always removed; data_owner is kept for sysadmins.
+    """
     pkg_dict.pop("maintainer_email", None)
-    pkg_dict.pop("data_owner", None)
+    if not is_sysadmin:
+        pkg_dict.pop("data_owner", None)
 
 
 @tk.blanket.blueprints
@@ -44,11 +65,12 @@ class DatavicODPSchema(p.SingletonPlugin):
     # IPackageController
     def after_dataset_show(self, context, pkg_dict):
         if _is_api_request(context):
-            _strip_custodian_fields(pkg_dict)
+            _strip_custodian_fields(pkg_dict, is_sysadmin=_is_sysadmin(context))
         return pkg_dict
 
     def after_dataset_search(self, search_results, search_params):
         if _is_api_request():
+            is_sysadmin = _is_sysadmin()
             for item in search_results.get("results", []):
-                _strip_custodian_fields(item)
+                _strip_custodian_fields(item, is_sysadmin=is_sysadmin)
         return search_results

--- a/ckanext/datavic_odp_schema/tests/conftest.py
+++ b/ckanext/datavic_odp_schema/tests/conftest.py
@@ -23,11 +23,14 @@ def _ensure_category_group() -> str:
     except tk.ObjectNotFound:
         site_user = tk.get_action("get_site_user")({"ignore_auth": True}, {})
         ctx = {"ignore_auth": True, "user": site_user["name"]}
-        tk.get_action("group_create")(ctx, {
-            "id": _CATEGORY_ID,
-            "name": "data-themes",
-            "title": "Data Themes",
-        })
+        tk.get_action("group_create")(
+            ctx,
+            {
+                "id": _CATEGORY_ID,
+                "name": "data-themes",
+                "title": "Data Themes",
+            },
+        )
     return _CATEGORY_ID
 
 
@@ -52,6 +55,13 @@ class DatasetFactory(factories.Dataset):
 
 
 register(DatasetFactory, "dataset")
+
+
+class UserFactory(factories.User):
+    pass
+
+
+register(UserFactory, "user")
 
 
 class GroupFactory(factories.Group):

--- a/ckanext/datavic_odp_schema/tests/test_custodian_fields.py
+++ b/ckanext/datavic_odp_schema/tests/test_custodian_fields.py
@@ -20,6 +20,23 @@ def _api_context():
     return ctx
 
 
+def _sysadmin_api_context():
+    return _api_context()
+
+
+def _normal_api_context(user):
+    return {"user": user["name"], "api_version": 3}
+
+
+def _anonymous_api_context():
+    return {"user": "", "api_version": 3}
+
+
+@pytest.fixture
+def normal_user(user_factory):
+    return user_factory()
+
+
 @pytest.fixture
 def custodian_dataset(dataset_factory):
     return dataset_factory(
@@ -31,19 +48,45 @@ def custodian_dataset(dataset_factory):
 
 @pytest.mark.usefixtures("clean_db", "clean_index")
 class TestCustodianFieldStripping:
-    def test_package_show_strips_on_api_request(self, custodian_dataset):
-        result = tk.get_action("package_show")(
-            _api_context(), {"id": custodian_dataset["id"]}
-        )
-        for field in CUSTODIAN_FIELDS:
-            assert field not in result
+    # --- package_show -------------------------------------------------------
 
-    def test_package_show_keeps_fields_for_internal_call(self, custodian_dataset):
+    def test_package_show_strips_both_for_normal_user(
+        self, custodian_dataset, normal_user
+    ):
+        result = tk.get_action("package_show")(
+            _normal_api_context(normal_user), {"id": custodian_dataset["id"]}
+        )
+        assert "maintainer_email" not in result
+        assert "data_owner" not in result
+
+    def test_package_show_strips_both_for_anonymous_api_request(
+        self, custodian_dataset
+    ):
+        result = tk.get_action("package_show")(
+            _anonymous_api_context(), {"id": custodian_dataset["id"]}
+        )
+        assert "maintainer_email" not in result
+        assert "data_owner" not in result
+
+    def test_package_show_sysadmin_keeps_data_owner_strips_maintainer_email(
+        self, custodian_dataset
+    ):
+        result = tk.get_action("package_show")(
+            _sysadmin_api_context(), {"id": custodian_dataset["id"]}
+        )
+        # data_owner retained for sysadmin (required field for the DD harvest)
+        assert result["data_owner"] == _DATA_OWNER
+        # maintainer_email always stripped from the API, even for sysadmins
+        assert "maintainer_email" not in result
+
+    def test_package_show_keeps_both_for_internal_call(self, custodian_dataset):
         result = tk.get_action("package_show")(
             _sysadmin_context(), {"id": custodian_dataset["id"]}
         )
         assert result["data_owner"] == _DATA_OWNER
         assert result["maintainer_email"] == _MAINTAINER_EMAIL
+
+    # --- write paths preserve the stored values -----------------------------
 
     def test_package_patch_preserves_custodian_fields(self, custodian_dataset):
         tk.get_action("package_patch")(
@@ -115,22 +158,68 @@ class TestCustodianFieldStripping:
         assert result["data_owner"] == _DATA_OWNER
         assert result["maintainer_email"] == _MAINTAINER_EMAIL
 
-    def test_package_search_strips_on_api_request(self, custodian_dataset):
+    # --- package_search -----------------------------------------------------
+    #
+    # after_dataset_search has no action context; it reads the request user from
+    # the CKAN-stashed Session._context (set by ckan/views/api.py). Tests stash
+    # {"user": <name>, "api_version": 3} to mimic that — no tk.current_user.
+
+    def _search_with_stashed_context(self, stashed_context, query_context, query):
         session = model.Session()
-        session._context = {"api_version": 3}
+        session._context = stashed_context
         try:
-            result = tk.get_action("package_search")(
-                _sysadmin_context(), {"q": custodian_dataset["name"]}
-            )
+            return tk.get_action("package_search")(query_context, {"q": query})
         finally:
             session._context = None
 
+    def test_package_search_strips_both_for_normal_user(
+        self, custodian_dataset, normal_user
+    ):
+        result = self._search_with_stashed_context(
+            {"user": normal_user["name"], "api_version": 3},
+            _normal_api_context(normal_user),
+            custodian_dataset["name"],
+        )
+
         assert result["count"] >= 1
         for pkg in result["results"]:
-            for field in CUSTODIAN_FIELDS:
-                assert field not in pkg
+            assert "maintainer_email" not in pkg
+            assert "data_owner" not in pkg
 
-    def test_package_search_keeps_fields_for_internal_call(self, custodian_dataset):
+    def test_package_search_strips_both_for_anonymous_api_request(
+        self, custodian_dataset
+    ):
+        result = self._search_with_stashed_context(
+            {"user": "", "api_version": 3},
+            _anonymous_api_context(),
+            custodian_dataset["name"],
+        )
+
+        assert result["count"] >= 1
+        for pkg in result["results"]:
+            assert "maintainer_email" not in pkg
+            assert "data_owner" not in pkg
+
+    def test_package_search_sysadmin_keeps_data_owner_strips_maintainer_email(
+        self, custodian_dataset
+    ):
+        sysadmin_name = tk.get_action("get_site_user")({"ignore_auth": True}, {})[
+            "name"
+        ]
+        result = self._search_with_stashed_context(
+            {"user": sysadmin_name, "api_version": 3},
+            _sysadmin_context(),
+            custodian_dataset["name"],
+        )
+
+        assert result["count"] >= 1
+        match = next(
+            pkg for pkg in result["results"] if pkg["id"] == custodian_dataset["id"]
+        )
+        assert match["data_owner"] == _DATA_OWNER
+        assert "maintainer_email" not in match
+
+    def test_package_search_keeps_both_for_internal_call(self, custodian_dataset):
         session = model.Session()
         session._context = None
         result = tk.get_action("package_search")(


### PR DESCRIPTION
## Summary

Jira: https://digital-vic.atlassian.net/browse/DATAVIC-990

Fixes a harvest failure where the Data Directory (running as a sysadmin)
receives datasets from the DataVic ODP API with `data_owner` stripped — a
mandatory field on both sides, causing validation to fail.

### Changes

- `maintainer_email` continues to be stripped from all API responses (public
  and sysadmin alike).
- `data_owner` is now retained for sysadmin API requests only; non-sysadmin
  and anonymous requests still have it stripped.
- Added `_is_sysadmin(context)` helper (fail-closed — strips if user cannot
  be determined).
- Updated tests to assert the two fields independently across all user types
  (normal, anonymous, sysadmin) for both `package_show` and `package_search`.