### PR TITLE
Release: 2.10.11 – organisation image cleanup & sysadmin data_owner API exemption

### DIFF
--- a/ckanext/datavic_odp_schema/cli/maintain.py
+++ b/ckanext/datavic_odp_schema/cli/maintain.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 import logging
 
 import click
+import mimetypes
+import os
+import shutil
 import tqdm
 from sqlalchemy.exc import SQLAlchemyError
 
 import ckan.logic as logic
 import ckan.model as model
 import ckan.plugins.toolkit as tk
+from ckan.lib.uploader import get_uploader
 from ckan.model import Resource, ResourceView
 
 from ckanext.datastore.backend import get_all_resources_ids_in_datastore
@@ -364,3 +368,138 @@ def make_datatables_view_prioritized():
         if result.get("updated"):
             number_reordered += 1
     click.secho(f"Reordered {number_reordered} resources", fg="green")
+
+
+@maintain.command("cleanup-group-images")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="List unused images without moving them.",
+)
+def cleanup_group_images(dry_run: bool):
+    """Move unused group/organisation images to a _unused subdirectory.
+
+    Fetches all organisations and groups, collects their image_url values,
+    then compares against files on disk.  Any file not referenced by an active
+    org or group is moved to <storage_path>/_unused for safe manual review.
+    """
+    storage_path = get_uploader("group").storage_path
+
+    if dry_run:
+        click.secho("Dry-run mode — no files will be moved.", fg="blue")
+
+    try:
+        referenced = _collect_referenced_group_images()
+    except Exception as e:
+        click.secho(f"Aborting: could not collect referenced images: {e}", fg="red")
+        log.error("cleanup-group-images aborted during collection: %s", e)
+        return
+
+    click.secho(
+        f"Found {len(referenced)} referenced image filename(s) across all orgs/groups.",
+        fg="green",
+    )
+
+    if not os.path.isdir(storage_path):
+        click.secho(f"Storage path does not exist: {storage_path}", fg="red")
+        return
+
+    unused_dir = os.path.join(storage_path, "_unused")
+
+    allowed_mimetypes: list[str] = tk.config.get(
+        "ckan.upload.group.mimetypes", ["image/png", "image/gif", "image/jpeg"]
+    )
+
+    disk_files: list[str] = []
+    for filename in os.listdir(storage_path):
+        filepath = os.path.join(storage_path, filename)
+        if not os.path.isfile(filepath):
+            continue
+        mimetype, _ = mimetypes.guess_type(filename)
+        if mimetype in allowed_mimetypes:
+            disk_files.append(filename)
+
+    unused: list[str] = []
+    for filename in disk_files:
+        if filename not in referenced:
+            unused.append(filename)
+
+    if not unused:
+        click.secho("No unused images found.", fg="green")
+        return
+
+    click.secho(f"Found {len(unused)} unused image(s).", fg="yellow")
+
+    if dry_run:
+        for filename in unused:
+            click.secho(f"  Would move: {filename}", fg="yellow")
+        return
+
+    os.makedirs(unused_dir, exist_ok=True)
+
+    moved = 0
+    skipped = 0
+    failed = 0
+    for filename in unused:
+        src = os.path.join(storage_path, filename)
+        dst = os.path.join(unused_dir, filename)
+        if os.path.exists(dst):
+            click.secho(
+                f"  Skipped (already in _unused): {filename}", fg="yellow"
+            )
+            log.warning(
+                "cleanup-group-images: skipped %s — destination already exists",
+                filename,
+            )
+            skipped += 1
+            continue
+        try:
+            shutil.move(src, dst)
+            click.secho(f"  Moved: {filename}", fg="yellow")
+            moved += 1
+        except OSError as e:
+            click.secho(f"  ERROR moving {filename}: {e}", fg="red")
+            log.error("Failed to move group image %s: %s", filename, e)
+            failed += 1
+
+    click.secho(
+        f"\nDone. {moved} moved, {skipped} skipped (already in _unused),"
+        f" {failed} failed.",
+        fg="green" if failed == 0 else "yellow",
+    )
+
+
+def _collect_referenced_group_images() -> set[str]:
+    """Return the set of image filenames referenced by all orgs and groups.
+
+    Raises an exception if the top-level list call for either orgs or groups
+    fails, so the caller can abort rather than treating all files as unused.
+    """
+    ctx = {"ignore_auth": True}
+    referenced: set[str] = set()
+
+    actions = [
+        ("organization_list", "organization_show"),
+        ("group_list", "group_show"),
+    ]
+
+    for list_action, detail_action in actions:
+        names: list[str] = tk.get_action(list_action)(ctx, {"all_fields": False})
+
+        for name in names:
+            try:
+                data = tk.get_action(detail_action)(
+                    ctx, {"id": name, "include_datasets": False}
+                )
+            except Exception as e:
+                log.warning(
+                    "Could not fetch %s for %s: %s", detail_action, name, e
+                )
+                continue
+
+            value = data.get("image_url") or ""
+            if value:
+                referenced.add(os.path.basename(value.rstrip("/")))
+
+    return referenced

--- a/ckanext/datavic_odp_schema/cli/maintain.py
+++ b/ckanext/datavic_odp_schema/cli/maintain.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 
 import click
-import mimetypes
 import os
 import shutil
 import tqdm
@@ -407,18 +406,12 @@ def cleanup_group_images(dry_run: bool):
 
     unused_dir = os.path.join(storage_path, "_unused")
 
-    allowed_mimetypes: list[str] = tk.config.get(
-        "ckan.upload.group.mimetypes", ["image/png", "image/gif", "image/jpeg"]
-    )
-
     disk_files: list[str] = []
     for filename in os.listdir(storage_path):
         filepath = os.path.join(storage_path, filename)
         if not os.path.isfile(filepath):
             continue
-        mimetype, _ = mimetypes.guess_type(filename)
-        if mimetype in allowed_mimetypes:
-            disk_files.append(filename)
+        disk_files.append(filename)
 
     unused: list[str] = []
     for filename in disk_files:

--- a/ckanext/datavic_odp_schema/plugin.py
+++ b/ckanext/datavic_odp_schema/plugin.py
@@ -1,5 +1,6 @@
 import logging
 
+import ckan.authz as authz
 import ckan.plugins as p
 import ckan.plugins.toolkit as tk
 
@@ -23,10 +24,30 @@ def _is_api_request(context=None):
     return bool(ctx.get("api_version")) and not ctx.get("for_update")
 
 
-def _strip_custodian_fields(pkg_dict):
-    """Remove sensitive custodian fields before returning a package dict to the public API."""
+def _is_sysadmin(context=None):
+    """Return True if the requesting user is a sysadmin, False otherwise (fail-closed)."""
+    ctx = context if context is not None else _session_context()
+    user = ctx.get("user")
+    if not user:
+        return False
+    try:
+        return authz.is_sysadmin(user)
+    except Exception:
+        log.warning(
+            "Could not determine sysadmin status for custodian stripping",
+            exc_info=True,
+        )
+        return False
+
+
+def _strip_custodian_fields(pkg_dict, is_sysadmin=False):
+    """Strip custodian fields from a package dict for public API responses.
+
+    maintainer_email is always removed; data_owner is kept for sysadmins.
+    """
     pkg_dict.pop("maintainer_email", None)
-    pkg_dict.pop("data_owner", None)
+    if not is_sysadmin:
+        pkg_dict.pop("data_owner", None)
 
 
 @tk.blanket.blueprints
@@ -44,11 +65,12 @@ class DatavicODPSchema(p.SingletonPlugin):
     # IPackageController
     def after_dataset_show(self, context, pkg_dict):
         if _is_api_request(context):
-            _strip_custodian_fields(pkg_dict)
+            _strip_custodian_fields(pkg_dict, is_sysadmin=_is_sysadmin(context))
         return pkg_dict
 
     def after_dataset_search(self, search_results, search_params):
         if _is_api_request():
+            is_sysadmin = _is_sysadmin()
             for item in search_results.get("results", []):
-                _strip_custodian_fields(item)
+                _strip_custodian_fields(item, is_sysadmin=is_sysadmin)
         return search_results

--- a/ckanext/datavic_odp_schema/tests/conftest.py
+++ b/ckanext/datavic_odp_schema/tests/conftest.py
@@ -23,11 +23,14 @@ def _ensure_category_group() -> str:
     except tk.ObjectNotFound:
         site_user = tk.get_action("get_site_user")({"ignore_auth": True}, {})
         ctx = {"ignore_auth": True, "user": site_user["name"]}
-        tk.get_action("group_create")(ctx, {
-            "id": _CATEGORY_ID,
-            "name": "data-themes",
-            "title": "Data Themes",
-        })
+        tk.get_action("group_create")(
+            ctx,
+            {
+                "id": _CATEGORY_ID,
+                "name": "data-themes",
+                "title": "Data Themes",
+            },
+        )
     return _CATEGORY_ID
 
 
@@ -52,6 +55,13 @@ class DatasetFactory(factories.Dataset):
 
 
 register(DatasetFactory, "dataset")
+
+
+class UserFactory(factories.User):
+    pass
+
+
+register(UserFactory, "user")
 
 
 class GroupFactory(factories.Group):

--- a/ckanext/datavic_odp_schema/tests/test_custodian_fields.py
+++ b/ckanext/datavic_odp_schema/tests/test_custodian_fields.py
@@ -20,6 +20,23 @@ def _api_context():
     return ctx
 
 
+def _sysadmin_api_context():
+    return _api_context()
+
+
+def _normal_api_context(user):
+    return {"user": user["name"], "api_version": 3}
+
+
+def _anonymous_api_context():
+    return {"user": "", "api_version": 3}
+
+
+@pytest.fixture
+def normal_user(user_factory):
+    return user_factory()
+
+
 @pytest.fixture
 def custodian_dataset(dataset_factory):
     return dataset_factory(
@@ -31,19 +48,45 @@ def custodian_dataset(dataset_factory):
 
 @pytest.mark.usefixtures("clean_db", "clean_index")
 class TestCustodianFieldStripping:
-    def test_package_show_strips_on_api_request(self, custodian_dataset):
-        result = tk.get_action("package_show")(
-            _api_context(), {"id": custodian_dataset["id"]}
-        )
-        for field in CUSTODIAN_FIELDS:
-            assert field not in result
+    # --- package_show -------------------------------------------------------
 
-    def test_package_show_keeps_fields_for_internal_call(self, custodian_dataset):
+    def test_package_show_strips_both_for_normal_user(
+        self, custodian_dataset, normal_user
+    ):
+        result = tk.get_action("package_show")(
+            _normal_api_context(normal_user), {"id": custodian_dataset["id"]}
+        )
+        assert "maintainer_email" not in result
+        assert "data_owner" not in result
+
+    def test_package_show_strips_both_for_anonymous_api_request(
+        self, custodian_dataset
+    ):
+        result = tk.get_action("package_show")(
+            _anonymous_api_context(), {"id": custodian_dataset["id"]}
+        )
+        assert "maintainer_email" not in result
+        assert "data_owner" not in result
+
+    def test_package_show_sysadmin_keeps_data_owner_strips_maintainer_email(
+        self, custodian_dataset
+    ):
+        result = tk.get_action("package_show")(
+            _sysadmin_api_context(), {"id": custodian_dataset["id"]}
+        )
+        # data_owner retained for sysadmin (required field for the DD harvest)
+        assert result["data_owner"] == _DATA_OWNER
+        # maintainer_email always stripped from the API, even for sysadmins
+        assert "maintainer_email" not in result
+
+    def test_package_show_keeps_both_for_internal_call(self, custodian_dataset):
         result = tk.get_action("package_show")(
             _sysadmin_context(), {"id": custodian_dataset["id"]}
         )
         assert result["data_owner"] == _DATA_OWNER
         assert result["maintainer_email"] == _MAINTAINER_EMAIL
+
+    # --- write paths preserve the stored values -----------------------------
 
     def test_package_patch_preserves_custodian_fields(self, custodian_dataset):
         tk.get_action("package_patch")(
@@ -115,22 +158,68 @@ class TestCustodianFieldStripping:
         assert result["data_owner"] == _DATA_OWNER
         assert result["maintainer_email"] == _MAINTAINER_EMAIL
 
-    def test_package_search_strips_on_api_request(self, custodian_dataset):
+    # --- package_search -----------------------------------------------------
+    #
+    # after_dataset_search has no action context; it reads the request user from
+    # the CKAN-stashed Session._context (set by ckan/views/api.py). Tests stash
+    # {"user": <name>, "api_version": 3} to mimic that — no tk.current_user.
+
+    def _search_with_stashed_context(self, stashed_context, query_context, query):
         session = model.Session()
-        session._context = {"api_version": 3}
+        session._context = stashed_context
         try:
-            result = tk.get_action("package_search")(
-                _sysadmin_context(), {"q": custodian_dataset["name"]}
-            )
+            return tk.get_action("package_search")(query_context, {"q": query})
         finally:
             session._context = None
 
+    def test_package_search_strips_both_for_normal_user(
+        self, custodian_dataset, normal_user
+    ):
+        result = self._search_with_stashed_context(
+            {"user": normal_user["name"], "api_version": 3},
+            _normal_api_context(normal_user),
+            custodian_dataset["name"],
+        )
+
         assert result["count"] >= 1
         for pkg in result["results"]:
-            for field in CUSTODIAN_FIELDS:
-                assert field not in pkg
+            assert "maintainer_email" not in pkg
+            assert "data_owner" not in pkg
 
-    def test_package_search_keeps_fields_for_internal_call(self, custodian_dataset):
+    def test_package_search_strips_both_for_anonymous_api_request(
+        self, custodian_dataset
+    ):
+        result = self._search_with_stashed_context(
+            {"user": "", "api_version": 3},
+            _anonymous_api_context(),
+            custodian_dataset["name"],
+        )
+
+        assert result["count"] >= 1
+        for pkg in result["results"]:
+            assert "maintainer_email" not in pkg
+            assert "data_owner" not in pkg
+
+    def test_package_search_sysadmin_keeps_data_owner_strips_maintainer_email(
+        self, custodian_dataset
+    ):
+        sysadmin_name = tk.get_action("get_site_user")({"ignore_auth": True}, {})[
+            "name"
+        ]
+        result = self._search_with_stashed_context(
+            {"user": sysadmin_name, "api_version": 3},
+            _sysadmin_context(),
+            custodian_dataset["name"],
+        )
+
+        assert result["count"] >= 1
+        match = next(
+            pkg for pkg in result["results"] if pkg["id"] == custodian_dataset["id"]
+        )
+        assert match["data_owner"] == _DATA_OWNER
+        assert "maintainer_email" not in match
+
+    def test_package_search_keeps_both_for_internal_call(self, custodian_dataset):
         session = model.Session()
         session._context = None
         result = tk.get_action("package_search")(


### PR DESCRIPTION
## Summary

### DATAVIC Tickets

**[DATAVIC-959](https://digital-vic.atlassian.net/browse/DATAVIC-959) — Duplicate organisation images on DV filestore**
- New `maintain cleanup-group-images` CLI command in `cli/maintain.py`: collects `image_url` from every organisation and group, then moves any file in the `group` uploader storage path that is not referenced to a `_unused` subdirectory for manual review
- `--dry-run` flag lists the files that would be moved without moving them
- Aborts before moving anything if `organization_list`/`group_list` fails, so a failed lookup cannot mark every file as unused; per-entity `organization_show`/`group_show` failures are logged and skipped
- Files already present in `_unused` are skipped rather than overwritten; command reports counts of moved, skipped and failed files
- No MIME-type filter — every unreferenced file in the storage path is considered, regardless of extension

**[DATAVIC-990](https://digital-vic.atlassian.net/browse/DATAVIC-990) — Regression: DV to DD harvester (non-VPS/local council publishing)**
- `_strip_custodian_fields()` in `plugin.py` takes an `is_sysadmin` argument: `maintainer_email` is always removed from API responses, `data_owner` is now retained for sysadmins
- New `_is_sysadmin()` helper resolves the requesting user through `ckan.authz.is_sysadmin`; fails closed (returns `False`) when there is no user or the check raises
- `after_dataset_show` passes the per-request sysadmin result through; `after_dataset_search` resolves it once per search rather than per result
- `tests/test_custodian_fields.py` covers sysadmin, authenticated non-sysadmin and anonymous API callers for both `package_show` and `package_search`; `package_search` cases stash the request context on `model.Session` to mimic `ckan/views/api.py`
- `tests/conftest.py` registers a `user` factory for the non-sysadmin cases


[DATAVIC-959]: https://digital-vic.atlassian.net/browse/DATAVIC-959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DATAVIC-990]: https://digital-vic.atlassian.net/browse/DATAVIC-990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ